### PR TITLE
Daisy

### DIFF
--- a/recipes-kernel/linux/linux-curie.inc
+++ b/recipes-kernel/linux/linux-curie.inc
@@ -6,6 +6,10 @@ require recipes-kernel/linux/linux-imx.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:${THISDIR}/linux-imx-3.0.35:"
 
+SRC_URI = "git://github.com/rdm-dev/linux-curie;branch=curie-3.0.101 \
+           file://defconfig \
+"
+
 SRC_URI += "file://defconfig"
 
 # patch for the hardware of "Marie Curie" board

--- a/recipes-kernel/linux/linux-curie_3.0.35.bb
+++ b/recipes-kernel/linux/linux-curie_3.0.35.bb
@@ -1,74 +1,8 @@
 
 include linux-curie.inc
 
-SRCREV = "bdde708ebfde4a8c1d3829578d3f6481a343533a"
+SRCREV = "681175b964d4f84755776260fa670f7aa20d13c7"
 #SRCREV = "0c58d0f15879856dd750223abeeb0410a0891ca2"
 LOCALVERSION = "-4.1.0+curie"
-
-# Patches need for Yocto and not applied by Freescale when doing 4.1.0 branch
-SRC_URI += "file://drm-vivante-Add-00-sufix-in-returned-bus-Id.patch \
-            file://epdc-Rename-mxcfb_epdc_kernel.h-to-mxc_epdc.h.patch \
-            file://0001-perf-tools-Fix-getrusage-related-build-failure-on-gl.patch \
-	    file://0002-ARM-7668-1-fix-memset-related-crashes-caused-by-rece.patch \
-	    file://0003-ARM-7670-1-fix-the-memset-fix.patch \
-	    file://0004-ENGR00271136-Fix-build-break-when-CONFIG_CLK_DEBUG-i.patch \
-           "
-SRC_URI += "file://0001-Fix-linking-errors-when-only-mx6q_sabresd-is-selecte.patch \
-            file://0001-Workaround-for-curie-reboot-issue.patch \
-            file://0002-Create-a-new-board-MX6Q_CURIE-for-Curie.-Keep-using-.patch \
-            file://0003-addition-of-USB-Host-OTG-support-for-Curie.patch \
-            file://0004-add-fec-init-for-Curie-PHY-driver-is-not-correct-so-.patch \
-            file://0005-remove-unused-UART3.patch \
-            file://0006-select-correct-usb_otg_id-for-Curie.patch \
-            file://0007-remove-unused-variable-ret-to-avoid-warning-in-Curie.patch \
-            file://0008-addition-of-RTL8211E-phy-driver.patch \
-            file://0009-reset-phy-before-fec_init.patch \
-            file://0010-rtc-init-for-Curie.patch \
-            file://0011-i2c-init-for-Curie.patch \
-            file://0012-PMIC-DVFS-init-for-Curie-gp_reg_id-soc_reg_id-are-re.patch \
-            file://0013-bus-freq-driver-init.patch \
-            file://0014-addition-of-low-level-PM-driver.patch \
-            file://0015-thermal-driver-init-for-Curie.patch \
-            file://0016-addition-of-vmmc-fixed-regulator.patch \
-            file://0017-remove-unused-header-sabresd_battery.h-for-Curie.patch \
-            file://0018-addition-of-SDHC-driver-for-Curie-SDHC2-is-used-for-.patch \
-            file://0019-SATA-driver-init-for-Curie.patch \
-            file://0020-OCOTP-driver-init-for-Curie.patch \
-            file://0021-enabling-Wi-Fi-module-for-Curie.patch \
-            file://0022-gpio-led-driver-for-Curie.patch \
-            file://0023-button-driver-init-for-Curie.patch \
-            file://0024-watchdog-driver-init-for-Curie.patch \
-            file://0025-sdma-driver-init-for-Curie.patch \
-            file://0026-hdmi-ipu-vpu-gpu-driver-for-Curie.patch \
-            file://0027-spdif-driver-init-for-Curie.patch \
-            file://0028-Set-bit-5-in-S-PDIF-register-SCR-clear-outgoing-vali.patch \
-            file://0029-PMU-driver-init.patch \
-            file://0030-fix-compiling-errors-in-sata-init.patch \
-            file://0031-disable-alloc-of-video-memory-for-v4l2.patch \
-           "
-
-SRC_URI += "file://0001-ENGR00266882-fix-SabreAuto-random-system-hang-issue.patch \
-            file://0002-ENGR00263482-fix-random-dma-flush-hang-in-monkey-tes.patch \
-            file://0003-ENGR00274782-fixed-gpu-crash-when-baseAddress-is-not.patch \
-            file://0004-ENGR00274478-fix-gpu-memory-multi-lock-failure.patch \
-            file://0005-ENGR00277045-1-fix-system-reboot-with-video-playback.patch \
-            file://0006-ENGR00278701-use-alloc_pages-instead-of-alloc_pages_.patch \
-            file://0007-ENGR00277045-2-align-gpu-baseaddr-with-ram-base-addr.patch \
-            file://0008-ENGR00277333-gpu-Enable-OT-limitation-for-gc880.patch \
-            file://0009-ENGR00284988-Camera-recording-kernel-crash-on-WFD-so.patch \
-            file://0010-ENGR00283031-GPU-Integrate-4.6.9p13-release-kernel-d.patch \
-            file://0011-ENGR00289999-fixed-gc880-invalid-command-state-messa.patch \
-            file://0012-ENGR00303820-887-refine-physical-address-check-for-e.patch \
-            file://0013-ENGR00306257-1027-fix-system-hang-up-issue-caused-by.patch \
-            file://0014-ENGR00278179-query-gpu-memory-with-seperate-types.patch \
-           "
-
-SRC_URI += "file://0001-Importing-rtl8189es_4.3.0-driver.patch \
-            file://0002-include-rtl8189es-driver-in-kernel-build.patch \
-            file://0003-Add-platform-specific-modifications-for-Curie.patch \
-            file://0004-don-t-printout-debug-message-when-DBG-is-off.patch \
-           "
-
-SRC_URI += "file://unionfs-2.6_for_3.0.101.diff"
 
 COMPATIBLE_MACHINE = "(mx6curie)"

--- a/recipes-rdm/hp-blob/files/dfservice.run
+++ b/recipes-rdm/hp-blob/files/dfservice.run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec sudo -u @HOMEPILOT_USER@ @HOMEPILOT_BASE@/bin/dfservice
+exec start-stop-daemon -S --pidfile /run/dfservice.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec @HOMEPILOT_BASE@/bin/dfservice

--- a/recipes-rdm/hp-blob/files/homepilot.run
+++ b/recipes-rdm/hp-blob/files/homepilot.run
@@ -3,4 +3,4 @@
 # XXX must be able to be deleted
 mkdir -p /etc/modules-load.d
 
-exec sudo -u @HOMEPILOT_USER@ -- /bin/sh -c @HOMEPILOT_BASE@/bin/homepilot
+exec start-stop-daemon -S --pidfile /run/homepilot.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec @HOMEPILOT_BASE@/bin/homepilot

--- a/recipes-rdm/hp-blob/files/jetty.run
+++ b/recipes-rdm/hp-blob/files/jetty.run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec sudo -i -u @HOMEPILOT_USER@ -- /bin/sh -c @HOMEPILOT_BASE@/bin/jetty
+exec start-stop-daemon -S --pidfile /run/jetty.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec @HOMEPILOT_BASE@/bin/jetty

--- a/recipes-rdm/hp-blob/files/z-way.run
+++ b/recipes-rdm/hp-blob/files/z-way.run
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-tty="/dev/ttyZWave"
-
-exec sudo -u @HOMEPILOT_USER@ -- /bin/sh -c "cd @ZWAY_BASE@ && LD_LIBRARY_PATH='./libzway:./libzwayhttp:./libzwayjs:/opt/v8/lib' exec ./z-way-server -D $tty"
+export LD_LIBRARY_PATH='./libzway:./libzwayhttp:./libzwayjs:/opt/v8/lib'
+cd @ZWAY_BASE@ && exec start-stop-daemon -S --pidfile /run/z-way.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec ./z-way-server

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -14,7 +14,7 @@ RDEPENDS_${PN} += "daemontools"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4072"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4079"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 

--- a/recipes-rdm/images/rdm-hp2.inc
+++ b/recipes-rdm/images/rdm-hp2.inc
@@ -3,7 +3,7 @@ HP2_INSTALL = "service-df \
 	${ZWAY_DEPS} \
 	libxml2 \
 	libftdi \
-	oracle-jse-jdk-arm7 \
+	openjdk-jdk-blob-arm7 \
 	zway-blob \
 	hp-blob \
         wrkeyupload \

--- a/recipes-rdm/system-image/system-image.bb
+++ b/recipes-rdm/system-image/system-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Meta recipe for recording system image version"
 
 LICENSE = "MIT"
-PV = "3.11.18"
+PV = "3.11.19"
 
 MAINTAINER=     "HP2 Dev Team <verteiler.hp2dev.team@rademacher.com>"
 HOMEPAGE=       "https://github.com/rdm-dev"

--- a/recipes-rdm/xbmc/xbmc-startup/xbmc
+++ b/recipes-rdm/xbmc/xbmc-startup/xbmc
@@ -8,4 +8,5 @@ echo 3 > /proc/sys/vm/drop_caches
 test -d /tmp/xbmc || setuidgid xbmc mkdir /tmp/xbmc
 rm -f ${HOME}/.xbmc/temp
 setuidgid xbmc ln -s /tmp/xbmc ${HOME}/.xbmc/temp
-exec 2>&1 start-stop-daemon --pidfile /run/xbmc.pid --make-pidfile --start --exec sudo -- -i -u xbmc /imx6/xbmc/lib/xbmc/xbmc.bin
+
+exec 2>&1 start-stop-daemon -S --pidfile /run/xbmc.pid --make-pidfile --chuid xbmc --exec /imx6/xbmc/lib/xbmc/xbmc.bin


### PR DESCRIPTION
- disable led for sysdetails
- decrease start delay of sysimg_update to 5 min
- fix typo in /etc/network/interfaces and set wpa-driver to nl80211
- enable reboot on kernel panic
- delay first start of xbmc and wait until psplash is closed
- disable tty1 to remove login screen
- add start-stop-daemon to startup scripts
- include openjdk-jdk-blob-arm7 in rdm-hp2
- update linux-curie to 3.0.101
- improve log filename in hp2sm