### PR TITLE
3.11.23

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,19 @@
 Revision history for HomePilot
 
+3.11.23 2015-01-30
+    - update hp-blob
+	* Removed SAC scheduling.
+	* 1-channel-actor acts like 2-channel-actor on automation-fixing.
+	* bug fix firmware ui: deinstall button reappears after click
+	* Removed Decor.ScheduleSac from propr. sensors.
+	* 1 channel actor acts like universal actor on automation fixing.
+    - fix wpa_supplicant startup
+    - update nginx-legal to 0.2
+        * remove oracle binary code license
+    - sleep 90 seconds before setting ledbootup into ready state
+    - hide nslookup output on boot
+    - update udev rules to support new z-wave stick
+
 3.11.22	2015-01-26
     - force /etc/daemontools into tmpfs
     - switch back to wext driver to stabilize wifi

--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/eth/post_down.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/eth/post_down.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-test -x /etc/network/if-pre-up.d/wpa-supplicant && /etc/network/if-pre-up.d/wpa-supplicant stop
 ifup wlan0

--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/eth/pre_up.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/eth/pre_up.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 ifdown wlan0
+test -x /etc/network/if-pre-up.d/wpa-supplicant && MODE=stop IF_WPA_CONF=/etc/wpa_supplicant.conf IFACE=wlan0 IF_WPA_DRIVER=wext /etc/network/if-pre-up.d/wpa-supplicant

--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/post_down.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/post_down.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-test -x /etc/network/if-pre-up.d/wpa-supplicant && /etc/network/if-pre-up.d/wpa-supplicant stop
+test -x /etc/network/if-pre-up.d/wpa-supplicant && /etc/network/if-pre-up.d/wpa-supplicant
 
 echo 0 > /sys/devices/platform/leds-gpio/leds/wifi/brightness

--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/pre_up.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/pre_up.sh
@@ -2,7 +2,7 @@
 
 test -r /etc/network/wifi/defaults && source /etc/network/wifi/defaults
 
-test -x /etc/network/if-pre-up.d/wpa-supplicant && /etc/network/if-pre-up.d/wpa-supplicant stop
+test -x /etc/network/if-pre-up.d/wpa-supplicant && MODE=stop /etc/network/if-pre-up.d/wpa-supplicant
 
 if [ -f /data/.shadow/.etc/wpa_supplicant.conf ] && grep -q ${wifi_module} ${wifi_modprobe_loaded_path}; then
     if [ $(lsmod | grep $wifi_module | wc -l) -eq 0 ]; then
@@ -11,5 +11,3 @@ if [ -f /data/.shadow/.etc/wpa_supplicant.conf ] && grep -q ${wifi_module} ${wif
 else
     exit 1
 fi
-
-test -x /etc/network/if-pre-up.d/wpa-supplicant && /etc/network/if-pre-up.d/wpa-supplicant start

--- a/recipes-core/initscripts/initscripts/wifi-fallback.sh
+++ b/recipes-core/initscripts/initscripts/wifi-fallback.sh
@@ -16,7 +16,7 @@ PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
 
 waitfornetwork(){
 	for i in $(seq 1 10); do
-		nslookup 0.de.pool.ntp.org && break
+		nslookup 0.de.pool.ntp.org 1>/dev/null 2>/dev/null && break
 		sleep 1
 	done
 }

--- a/recipes-httpd/nginx/nginx_%.bbappend
+++ b/recipes-httpd/nginx/nginx_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "http://internal.rdm.local/blobs/nginx-legal-0.1.tar.gz \
+SRC_URI += "http://internal.rdm.local/blobs/nginx-legal-0.2.tar.gz \
 	http://internal.rdm.local/blobs/nginx-manual-0.3.tar.gz \
 	http://internal.rdm.local/blobs/nginx-html-0.2.tar.gz \
 	file://nginx-varlib.volatiles \

--- a/recipes-rdm/hp-blob/hp-blob_svn.bb
+++ b/recipes-rdm/hp-blob/hp-blob_svn.bb
@@ -14,7 +14,7 @@ RDEPENDS_${PN} += "zway-blob"
 
 inherit record-installed-app
 
-HPREV="4088"
+HPREV="4125"
 PV = "4.0.${HPREV}"
 SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_Blob/trunk/;protocol=http;module=HomePilot_Blob;rev=${HPREV} \
                 file://dfservice.run \

--- a/recipes-rdm/ledctrl/ledctrl/ledbootup.sh
+++ b/recipes-rdm/ledctrl/ledctrl/ledbootup.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# Frank measured 45 seconds between LED turned into ready state and every application is runnning
-# sleep 60 seconds just to be sure
+# Frank measured >45 seconds between LED turned into ready state and every application is runnning
+# sleep 90 seconds just to be sure
 
-sleep 60s
+sleep 90s
 
 echo none >/sys/class/leds/boot/trigger
 echo 0 >/sys/class/leds/boot/brightness

--- a/recipes-rdm/system-image/system-image.bb
+++ b/recipes-rdm/system-image/system-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Meta recipe for recording system image version"
 
 LICENSE = "MIT"
-PV = "3.11.23"
+PV = "3.11.24"
 
 MAINTAINER=     "HP2 Dev Team <verteiler.hp2dev.team@rademacher.com>"
 HOMEPAGE=       "https://github.com/rdm-dev"


### PR DESCRIPTION
- update hp-blob
    * Removed SAC scheduling.
    * 1-channel-actor acts like 2-channel-actor on automation-fixing.
    * bug fix firmware ui: deinstall button reappears after click
    * Removed Decor.ScheduleSac from propr. sensors.
    * 1 channel actor acts like universal actor on automation fixing.
- fix wpa_supplicant startup
- update nginx-legal to 0.2
    * remove oracle binary code license
- sleep 90 seconds before setting ledbootup into ready state
- hide nslookup output on boot