### PR TITLE
3.11.25

### DIFF
--- a/recipes-core/initscripts/initscripts/volatiles
+++ b/recipes-core/initscripts/initscripts/volatiles
@@ -41,3 +41,4 @@ f root root 0664 /var/log/wtmp none
 f root root 0664 /var/run/utmp none
 l root root 0644 /etc/resolv.conf /var/run/resolv.conf
 f root root 0644 /var/run/resolv.conf none
+d root root 0755 /data/.var/lib/urandom none

--- a/recipes-extended/procps/files/sysctl.conf
+++ b/recipes-extended/procps/files/sysctl.conf
@@ -62,6 +62,6 @@ net.ipv4.conf.all.rp_filter=1
 #
 
 #kernel.shmmax = 141762560
-kernel.panic = -1
+kernel.panic = 5
 kernel.panic_on_oops = 1
 vm.panic_on_oom = 1

--- a/recipes-rdm/hp-blob/files/z-way.run
+++ b/recipes-rdm/hp-blob/files/z-way.run
@@ -1,4 +1,8 @@
 #!/bin/sh
 
+sleep 2
+echo -ne "\x01\x03\x00\x08\xf4" > /dev/ttyZWave
+sleep 5
+
 export LD_LIBRARY_PATH='./libzway:./libzwayhttp:./libzwayjs:/opt/v8/lib'
 cd @ZWAY_BASE@ && exec start-stop-daemon -S --pidfile /run/z-way.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec ./z-way-server

--- a/recipes-rdm/hp-blob/hp-blob_svn.bb
+++ b/recipes-rdm/hp-blob/hp-blob_svn.bb
@@ -14,7 +14,7 @@ RDEPENDS_${PN} += "zway-blob"
 
 inherit record-installed-app
 
-HPREV="4125"
+HPREV="4137"
 PV = "4.0.${HPREV}"
 SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_Blob/trunk/;protocol=http;module=HomePilot_Blob;rev=${HPREV} \
                 file://dfservice.run \

--- a/recipes-rdm/hp2sm/files/hp2sm.run
+++ b/recipes-rdm/hp2sm/files/hp2sm.run
@@ -5,7 +5,7 @@ NAME="HomePilot2 Service Monitor"
 PLACK_APP="/opt/rdm/hp2sm/bin/app.pl"
 PLACK_PORT=8081
 CWD=`pwd`
-OPTIONS="--port ${PLACK_PORT} ${PLACK_APP} "
+OPTIONS="--env production --port ${PLACK_PORT} ${PLACK_APP} "
 
 PIDFILE="/var/run/$NAME.pid"
 

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4111"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4139"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 

--- a/recipes-rdm/prd/prd-flash/flash-device.sh
+++ b/recipes-rdm/prd/prd-flash/flash-device.sh
@@ -115,9 +115,13 @@ then
     test -e /dev/mmcblk1 || reboot
 elif [ -f "${IMAGE_CONTAINER}" ]
 then
+    if [ -e ./.settings ]
+    then
+	logger -s "Flash already in progress."
+	exit 1
+    fi
     tar xjf "${IMAGE_CONTAINER}" .settings
     . ./.settings
-    rm -f .settings
 
     ROOTDEV=`mount | grep "on / type" | sed -e 's/ on.*//'`
     if [ ! $(echo ${ROOTDEV} | egrep "^${SDCARD_DEVICE}") ]
@@ -153,6 +157,7 @@ then
 	logger "Force rebuild of volatiles.cache next boot"
         rm -f /etc/volatile.cache
 
+	rm -f .settings
 	logger "Requesting reboot"
 	reboot
     elif [ $(echo ${ROOTDEV} | egrep 'p3$') ]
@@ -187,9 +192,11 @@ then
 	logger "Force rebuild of volatiles.cache next boot"
         rm -f /etc/volatile.cache
 
+	rm -f .settings
 	logger "Requesting reboot"
 	reboot
     else
+	rm -f .settings
 	logger -s "Cannot detect normal mode nor recovery mode. Fix and retry."
 	exit 1
     fi

--- a/recipes-rdm/system-image/system-image-update_git.bb
+++ b/recipes-rdm/system-image/system-image-update_git.bb
@@ -11,7 +11,7 @@ HOMEPAGE=	"https://github.com/rehsack/System-Image-Update"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Artistic-1.0;md5=cda03bbdc3c1951996392b872397b798 \
 file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-SRC_URI = "git://github.com/rehsack/System-Image-Update.git;rev=a10f68445c3424aec5a473e48527f77a6d24cba1 \
+SRC_URI = "git://github.com/rehsack/System-Image-Update.git;rev=399383a08a2dcd26ecc6cd93933f000d952b8885 \
            file://run \
 	   file://sysimg_update.json \
 "
@@ -19,7 +19,6 @@ SRC_URI = "git://github.com/rehsack/System-Image-Update.git;rev=a10f68445c3424ae
 RDEPENDS_${PN} += "archive-peek-libarchive-perl"
 RDEPENDS_${PN} += "crypt-ripemd160-perl"
 RDEPENDS_${PN} += "datetime-format-strptime-perl"
-RDEPENDS_${PN} += "file-libmagic-perl"
 RDEPENDS_${PN} += "log-any-adapter-dispatch-perl"
 RDEPENDS_${PN} += "moo-perl"
 RDEPENDS_${PN} += "moox-configfromfile-perl"

--- a/recipes-rdm/system-image/system-image.bb
+++ b/recipes-rdm/system-image/system-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Meta recipe for recording system image version"
 
 LICENSE = "MIT"
-PV = "3.11.24"
+PV = "3.11.25"
 
 MAINTAINER=     "HP2 Dev Team <verteiler.hp2dev.team@rademacher.com>"
 HOMEPAGE=       "https://github.com/rdm-dev"


### PR DESCRIPTION
- Bail out flash procedure when already running
- Update sysimg_update to avoid end-user issues
- Revert "reboot immediately on kernel panic"
- fix urandom start/stop
- improve z-way startup (reboot chip)
- update hp2sm
    * disable ssh key management
    * remove deployment wizard
- improve hp2sm startup: use production environment
- update hp-blob
    * new language files and firmware ui bugfix
    * firmware ui idle bugfix