### PR TITLE
3.11.25

### DIFF
--- a/recipes-rdm/hp-blob/hp-blob_svn.bb
+++ b/recipes-rdm/hp-blob/hp-blob_svn.bb
@@ -14,7 +14,7 @@ RDEPENDS_${PN} += "zway-blob"
 
 inherit record-installed-app
 
-HPREV="4137"
+HPREV="4141"
 PV = "4.0.${HPREV}"
 SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_Blob/trunk/;protocol=http;module=HomePilot_Blob;rev=${HPREV} \
                 file://dfservice.run \

--- a/recipes-rdm/xbmc/xbmc-custom-settings-13/advancedsettings.xml
+++ b/recipes-rdm/xbmc/xbmc-custom-settings-13/advancedsettings.xml
@@ -9,10 +9,14 @@
   <curllowspeedtime>5</curllowspeedtime>  <!-- Time in seconds for libcurl to consider a connection lowspeed -->
   <httpproxyusername></httpproxyusername>  <!-- username for Basic Proxy Authentication -->
   <httpproxypassword></httpproxypassword>  <!-- password for Basic Proxy Authentication -->
-  <cachemembuffersize>5242880</cachemembuffersize>  <!-- number of bytes used for buffering streams ahead in memory 
-    XBMC will not buffer ahead more than this. WARNING: for the bytes set here, XBMC will consume 3x the amount of RAM
-    When set to 0 the cache will be written to disk instead of RAM, as of v12 Frodo -->
-  <alwaysforcebuffer>1</alwaysforcebuffer>  <!-- enables cache for all streams with the exclusion of local DVD and local Blu-Ray. 0/off is default. -->
+  <cachemembuffersize>33554432</cachemembuffersize>  <!-- number of bytes used for buffering streams ahead in memory
+   {{subst:Name}} will not buffer ahead more than this. WARNING: for the bytes set here, {{subst:Name}} will consume 3x the amount of RAM
+   When set to 0 the cache will be written to disk instead of RAM, as of v12 Frodo -->
+  <buffermode>1</buffermode>  <!-- Choose what to buffer:
+    0) Buffer all internet filesystems (like "2" but additionally also ftp, webdav, etc.) (default)
+    1) Buffer all filesystems (including local)
+    2) Only buffer true internet filesystems (streams) (http, etc.)
+    3) No buffer -->
   <readbufferfactor>4.0</readbufferfactor> <!-- this factor determines the max readrate in terms of readbufferfactor * avg bitrate of a video file.
 This can help on bad connections to keep the cache filled. It will also greatly speed up buffering. Default value 1.0. -->
 </network>


### PR DESCRIPTION
- improve xbmc configuration
    * increase buffer for playing streams
        * tested with local media, smb and ftp streams
        * set limit to 32 MB because more cache was never used by xbmc
    * correct deprecated parameter
- update hp-blob
    * reduced backup size