### PR TITLE
Daisy 4.0.5

### DIFF
--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/post_down.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/post_down.sh
@@ -2,4 +2,4 @@
 
 test -x /etc/network/if-pre-up.d/wpa-supplicant && /etc/network/if-pre-up.d/wpa-supplicant
 
-echo 0 > /sys/devices/platform/leds-gpio/leds/wifi/brightness
+echo 0 > /sys/class/leds/wifi/brightness

--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/post_up.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/post_up.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Enable LED
-echo 255 > /sys/devices/platform/leds-gpio/leds/wifi/brightness
+echo 255 > /sys/class/leds/wifi/brightness

--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/pre_down.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/wifi/pre_down.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo 0 > /sys/devices/platform/leds-gpio/leds/wifi/brightness 
+echo 0 > /sys/class/leds/wifi/brightness

--- a/recipes-core/udev/udev-extraconf/platform-gpio-keys.rules
+++ b/recipes-core/udev/udev-extraconf/platform-gpio-keys.rules
@@ -1,0 +1,2 @@
+# Only root has r/w permission to gpio keys
+SUBSYSTEM=="input", ATTRS{name}=="gpio-keys.21", GROUP="root"

--- a/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/recipes-core/udev/udev-extraconf_%.bbappend
@@ -3,12 +3,14 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI_append_mx6 = " file://10-imx-hdmi.rules \
                        file://10-galcore.rules \
+		       file://platform-gpio-keys.rules \
 "
 
 do_install_prepend_mx6 () {
 	install -d ${D}${sysconfdir}/udev/rules.d
 	install -m 0644 ${WORKDIR}/10-imx-hdmi.rules ${D}${sysconfdir}/udev/rules.d
 	install -m 0644 ${WORKDIR}/10-galcore.rules ${D}${sysconfdir}/udev/rules.d
+	install -m 0644 ${WORKDIR}/platform-gpio-keys.rules ${D}${sysconfdir}/udev/rules.d
 }
 
 PACKAGE_ARCH_mx6 = "${MACHINE_ARCH}"

--- a/recipes-rdm/hp-blob/files/homepilot.run
+++ b/recipes-rdm/hp-blob/files/homepilot.run
@@ -3,4 +3,6 @@
 # XXX must be able to be deleted
 mkdir -p /etc/modules-load.d
 
+test -f /var/log/hp2/server.log && mv /var/log/hp2/server.log /var/log/hp2/server.log.old
+
 exec start-stop-daemon -S --pidfile /run/homepilot.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec @HOMEPILOT_BASE@/bin/homepilot

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4275"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4282"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4282"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4325"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 


### PR DESCRIPTION
- archive homepilot log files on startup
- fix path for wifi led
- limit r/w permissions for gpio keys
- update hp2sm
    - add kodi page with spdif settings
    - add reset for homepilot, multimedia, system or all configurations
    - add zwave page
    - improve ssh key management: check device-root.no_warranty and user button


