### PR TITLE
4.0.6 3

### DIFF
--- a/recipes-extended/daemontools-encore/daemontools-encore_git.bb
+++ b/recipes-extended/daemontools-encore/daemontools-encore_git.bb
@@ -57,3 +57,6 @@ do_install () {
     install -d ${D}${sysconfdir}/sudoers.d
     install -m 600 ${WORKDIR}/sv-enc-as-users.sudoers ${D}${sysconfdir}/sudoers.d/sv-enc-as-users
 }
+
+PROVIDES = "daemontools"
+RPROVIDES_${PN} = "daemontools"

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4376"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4381"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 


### PR DESCRIPTION
- update hp2sm
    - improve ssh key management
        - overwrite ~/.ssh/authorized_keys
        - use another user for ssh access
- improve daemontools-encore
    - daemontools-encore provides daemontools