### PR TITLE
4.0.7

### DIFF
--- a/conf/machine/curie.conf
+++ b/conf/machine/curie.conf
@@ -29,8 +29,8 @@ PREFERRED_PROVIDER_u-boot = "u-boot-curie"
 PREFERRED_PROVIDER_virtual/kernel := "linux-curie"
 
 include conf/machine/include/u-boot-2013.04.inc
-#include conf/machine/include/linux-3.0-4.1.inc
-include conf/machine/include/linux-3.10-1.0.inc
+include conf/machine/include/linux-3.0-4.1.inc
+#include conf/machine/include/linux-3.10-1.0.inc
 
 MACHINE_FEATURES_remove = " phone irda usbgadget 3g nfc "
 DISTRO_FEATURES_remove = " phone irda usbgadget 3g nfc "

--- a/recipes-kernel/linux/linux-curie-3.0.35/0001-Patch-to-tune-mx6-HDMI-parameters.patch
+++ b/recipes-kernel/linux/linux-curie-3.0.35/0001-Patch-to-tune-mx6-HDMI-parameters.patch
@@ -1,0 +1,64 @@
+From 524acd707db977c1de75fa0821744e9b172b65b5 Mon Sep 17 00:00:00 2001
+From: Cui Gao <gao.cui@windsolve.com>
+Date: Wed, 15 Apr 2015 22:06:18 +0800
+Subject: [PATCH] Patch to tune mx6 HDMI parameters
+
+  Add two bootargs txterm&vlev to make the HDMI phy parameters
+  changable in u-boot.
+---
+ drivers/video/mxc_hdmi.c | 26 ++++++++++++++++++++++++--
+ 1 file changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/video/mxc_hdmi.c b/drivers/video/mxc_hdmi.c
+index c5069aa..25abdf0 100644
+--- a/drivers/video/mxc_hdmi.c
++++ b/drivers/video/mxc_hdmi.c
+@@ -971,6 +971,25 @@ static void mxc_hdmi_phy_sel_interface_control(u8 enable)
+ 			HDMI_PHY_CONF0_SELDIPIF_MASK);
+ }
+ 
++static int txterm = 0x0005;
++static int vlev = 0x01ad;
++
++#ifndef MODULE
++static int __init txterm_setup(char *str)
++{
++	txterm = simple_strtol(str, NULL, 0);
++	return 1;
++}
++__setup("txterm=", txterm_setup);
++
++static int __init vlev_setup(char *str)
++{
++	vlev = simple_strtol(str, NULL, 0);
++	return 1;
++}
++__setup("vlev=", vlev_setup);
++#endif
++
+ static int hdmi_phy_configure(struct mxc_hdmi *hdmi, unsigned char pRep,
+ 			      unsigned char cRes, int cscOn)
+ {
+@@ -1178,14 +1197,17 @@ static int hdmi_phy_configure(struct mxc_hdmi *hdmi, unsigned char pRep,
+ 		return false;
+ 	}
+ 
++	printk("** HDMI TXTERM=%08x\n", txterm);
++	printk("** HDMI VLEV=%08x\n", vlev);
++
+ 	hdmi_phy_i2c_write(hdmi, 0x0000, 0x13);  /* PLLPHBYCTRL */
+ 	hdmi_phy_i2c_write(hdmi, 0x0006, 0x17);
+ 	/* RESISTANCE TERM 133Ohm Cfg */
+-	hdmi_phy_i2c_write(hdmi, 0x0005, 0x19);  /* TXTERM */
++	hdmi_phy_i2c_write(hdmi, txterm, 0x19);  /* TXTERM */
+ 	/* PREEMP Cgf 0.00 */
+ 	hdmi_phy_i2c_write(hdmi, 0x800d, 0x09);  /* CKSYMTXCTRL */
+ 	/* TX/CK LVL 10 */
+-	hdmi_phy_i2c_write(hdmi, 0x01ad, 0x0E);  /* VLEVCTRL */
++	hdmi_phy_i2c_write(hdmi, vlev, 0x0E);  /* VLEVCTRL */
+ 
+ 	/* Board specific setting for PHY register 0x09, 0x0e to pass HCT */
+ 	if (hdmi->phy_config.reg_cksymtx != 0)
+-- 
+1.9.1
+

--- a/recipes-kernel/linux/linux-curie_3.0.35.bb
+++ b/recipes-kernel/linux/linux-curie_3.0.35.bb
@@ -23,6 +23,7 @@ SRC_URI += "file://physeries.scc \
             file://physeries-user-patches.scc \
             file://Merge-patches-for-CEC-issues-from-wolfgar.patch \
             file://use-dma-pool.patch \
+	    file://0001-Patch-to-tune-mx6-HDMI-parameters.patch \
             file://bootscript \
             file://bootscript.nfs \
            "

--- a/recipes-rdm/images/rdm.inc
+++ b/recipes-rdm/images/rdm.inc
@@ -28,7 +28,6 @@ RDM_BASE_INSTALL = "hp2sm \
 	xz \
 	lsof \
 	logrotate \
-	collectd \
 "
 RDM_INSTALL = "${RDM_BASE_INSTALL} \
 	udev-extraconf \


### PR DESCRIPTION
- add patch for linux-curie-3.0.101 to tune mx6 HDMI parameters
- pick linux-curie-3.0.101
- temporarily disable collectd
