### PR TITLE
4.0.8 1

### DIFF
--- a/recipes-httpd/nginx/nginx_%.bbappend
+++ b/recipes-httpd/nginx/nginx_%.bbappend
@@ -1,16 +1,16 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "http://internal.rdm.local/blobs/nginx-legal-0.2.tar.gz;name=legal \
-	http://internal.rdm.local/blobs/nginx-manual-0.3.tar.gz;name=manual \
+	http://internal.rdm.local/blobs/nginx-manual-0.4.tar.gz;name=manual \
 	http://internal.rdm.local/blobs/nginx-html-0.2.tar.gz;name=html \
 	file://nginx-varlib.volatiles \
 "
 
 SRC_URI[legal.md5sum] = "ccb221827f2bcd827cca8db6a3d14d70"
-SRC_URI[manual.md5sum] = "105ca148d474f0271efcbbe2fff48f50"
+SRC_URI[manual.md5sum] = "d42c56ce54078c53bb8a4a151bb89eeb"
 SRC_URI[html.md5sum] = "ab456627a7b5871badb77995c95a61a4"
 SRC_URI[legal.sha256sum] = "f8643b50b34b5cf5ce483bf01012f97dc35b2d0a5b79adbe2d73042ca47edf1e"
-SRC_URI[manual.sha256sum] = "c98e55c4c331664a789551b9e17140836a3406b1a2603cf13306b220d833cb6f"
+SRC_URI[manual.sha256sum] = "17e16a35206b2a0379d758a5b0f355e095db5064ee51e91d26cea3c527edc50c"
 SRC_URI[html.sha256sum] = "c370d6fce8a81fb2bf5ba0454d230263ea4ec57aa50626ca8fccb3a5269be17c"
 
 do_install_append () {

--- a/recipes-rdm/hp-blob/files/z-way-log.run
+++ b/recipes-rdm/hp-blob/files/z-way-log.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec multilog t /var/log/daemontools/z-way

--- a/recipes-rdm/hp-blob/files/z-way.run
+++ b/recipes-rdm/hp-blob/files/z-way.run
@@ -5,4 +5,4 @@ echo -ne "\x01\x03\x00\x08\xf4" > /dev/ttyZWave
 sleep 5
 
 export LD_LIBRARY_PATH='./libzway:./libzwayhttp:./libzwayjs:/opt/v8/lib'
-cd @ZWAY_BASE@ && exec start-stop-daemon -S --pidfile /run/z-way.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec ./z-way-server
+cd @ZWAY_BASE@ && exec 2>&1 start-stop-daemon -S --pidfile /run/z-way.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec ./z-way-server

--- a/recipes-rdm/hp-blob/hp-blob_svn.bb
+++ b/recipes-rdm/hp-blob/hp-blob_svn.bb
@@ -25,6 +25,7 @@ SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_Blob/trunk/;protocol=http;modul
                 file://jetty.run \
                 file://jetty.sh \
                 file://z-way.run \
+                file://z-way-log.run \
                 file://init_appdir.sh \
                 file://gpg/pubring.gpg \
                 file://gpg/random_seed \
@@ -77,6 +78,7 @@ do_install() {
 	install -d ${D}${SVC_SERVICES}/homepilot/log
 	install -d ${D}${SVC_SERVICES}/jetty
 	install -d ${D}${SVC_SERVICES}/z-way
+	install -d ${D}${SVC_SERVICES}/z-way/log
 
 	# 2 Move all the run-files
 	install -m 0755 ${WORKDIR}/homepilot-network-manager.run ${D}${SVC_SERVICES}/homepilot-network-manager/run
@@ -87,6 +89,7 @@ do_install() {
 	install -m 0755 ${WORKDIR}/jetty.run ${D}${SVC_SERVICES}/jetty/run
 	install -m 0755 ${WORKDIR}/jetty.sh ${D}${INST_DEST_PREFIX}/bin/jetty
 	install -m 0755 ${WORKDIR}/z-way.run ${D}${SVC_SERVICES}/z-way/run
+	install -m 0755 ${WORKDIR}/z-way-log.run ${D}${SVC_SERVICES}/z-way/log/run
 
 	# 
 	sed -i -e "s,@HOMEPILOT_BASE@,${INST_DEST_PREFIX},g" -e "s,@ZWAY_BASE@,${ZWAY_DEST_PREFIX},g"  \

--- a/recipes-rdm/hp2-base/files/hp2.volatiles
+++ b/recipes-rdm/hp2-base/files/hp2.volatiles
@@ -1,2 +1,3 @@
 d homepilot users 0755 /data/.var/log/hp2 none
 d homepilot users 0755 /data/.var/log/daemontools/homepilot none
+d homepilot users 0755 /data/.var/log/daemontools/z-way none

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4381"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4510"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4510"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4512"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 

--- a/recipes-rdm/images/rdm-xbmc.inc
+++ b/recipes-rdm/images/rdm-xbmc.inc
@@ -3,5 +3,6 @@ XBMC_INSTALL = "bkeymaps \
 	libcec \
 	xbmc \
 	xbmc-rdm-hp-addon \
+	xbmc-custom-settings \
 	xbmc-startup \
         "

--- a/recipes-rdm/xbmc/xbmc-custom-settings_13.bb
+++ b/recipes-rdm/xbmc/xbmc-custom-settings_13.bb
@@ -13,7 +13,7 @@ SRC_URI = "file://advancedsettings.xml \
 "
 
 XBMC_USER = "xbmc"
-XBMC_HOME = "/home/xbmc/.kodi"
+XBMC_HOME = "/home/xbmc/${XBMC_APPLICATION_DIRECTORY_BASE}"
 XBMC_USERDATA = "${XBMC_HOME}/userdata"
 
 do_install () {

--- a/recipes-rdm/xbmc/xbmc-rdm-hp-addon_git.bb
+++ b/recipes-rdm/xbmc/xbmc-rdm-hp-addon_git.bb
@@ -12,7 +12,7 @@ DEPENDS += "xbmc-startup"
 RDEPENDS_${PN} += "xbmc-startup"
 
 XBMC_USER_HOME = "/home/xbmc"
-XBMC_APPDIR = "${XBMC_USER_HOME}/.kodi"
+XBMC_APPDIR = "${XBMC_USER_HOME}/${XBMC_APPLICATION_DIRECTORY_BASE}"
 XBMC_ADDONS = "${XBMC_APPDIR}/addons"
 
 S = "${WORKDIR}/git/script.homepilot/"

--- a/recipes-rdm/zway/files/config.xml
+++ b/recipes-rdm/zway/files/config.xml
@@ -9,8 +9,8 @@
     <automation-dir>automation</automation-dir>
     <shell-script-on-save-xml>sync</shell-script-on-save-xml>                            
     <shell-script-on-save-http>sync</shell-script-on-save-http>                          
-    <log-file>/dev/null</log-file>
-    <log-level>0</log-level>
+    <log-file></log-file>
+    <log-level>4</log-level>
     <http-log-file>/dev/null</http-log-file>
     <http-log-level>4</http-log-level>
 </config>


### PR DESCRIPTION
- add z-way log and set default log-level to error
- enable xbmc-custom-settings
- fix path for xbmc/kodi application directory
- update hp2sm
    - add log-level configuration for z-way
    - fix reset
        - adjust mindepth for homepilot, xbmc/kodi and system configurations
- update nginx-manual
    - add ip camera

