### PR TITLE
4.0.14

### DIFF
--- a/recipes-connectivity/openvpn/openvpn_2.3.6.bb
+++ b/recipes-connectivity/openvpn/openvpn_2.3.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://openvpn.sourceforge.net"
 SECTION = "console/network"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5aac200199fde47501876cba7263cb0c"
-DEPENDS = "lzo openssl"
+DEPENDS = "libpam lzo openssl"
 
 inherit autotools
 

--- a/recipes-extended/collectd/collectd/collectd-logrotate.conf
+++ b/recipes-extended/collectd/collectd/collectd-logrotate.conf
@@ -1,0 +1,4 @@
+/var/log/collectd.log {
+    missingok
+    compress
+}

--- a/recipes-extended/collectd/collectd/collectd-logrotate.conf
+++ b/recipes-extended/collectd/collectd/collectd-logrotate.conf
@@ -1,4 +1,5 @@
 /var/log/collectd.log {
     missingok
     compress
+    size 1M
 }

--- a/recipes-extended/collectd/collectd/collectd.conf
+++ b/recipes-extended/collectd/collectd/collectd.conf
@@ -46,10 +46,10 @@ LoadPlugin logfile
 	PrintSeverity true
 </Plugin>
 
-LoadPlugin syslog
-<Plugin syslog>
-	LogLevel notice
-</Plugin>
+#LoadPlugin syslog
+#<Plugin syslog>
+#	LogLevel notice
+#</Plugin>
 
 ##############################################################################
 # LoadPlugin section                                                         #

--- a/recipes-extended/collectd/collectd/collectd.init
+++ b/recipes-extended/collectd/collectd/collectd.init
@@ -1,0 +1,225 @@
+#!/bin/sh
+#
+# collectd - start and stop the statistics collection daemon
+# http://collectd.org/
+#
+# Copyright (C) 2005-2006 Florian Forster <octo@verplant.org>
+# Copyright (C) 2006-2009 Sebastian Harl <tokkee@debian.org>
+#
+
+### BEGIN INIT INFO
+# Provides:          collectd
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Should-Start:      $network $named $syslog $time cpufrequtils
+# Should-Stop:       $network $named $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: manage the statistics collection daemon
+# Description:       collectd is the statistics collection daemon.
+#                    It is a small daemon which collects system information
+#                    periodically and provides mechanisms to monitor and store
+#                    the values in a variety of ways.
+### END INIT INFO
+
+. /etc/init.d/functions
+
+export PATH=/sbin:/bin:/usr/sbin:/usr/bin
+
+DISABLE=0
+
+NAME=collectd
+DAEMON=/usr/sbin/collectd
+
+CONFIGFILE=/etc/collectd.conf
+PIDFILE=/var/run/collectd.pid
+
+USE_COLLECTDMON=1
+COLLECTDMON_DAEMON=/usr/sbin/collectdmon
+COLLECTDMON_PIDFILE=/var/run/collectdmon.pid
+
+MAXWAIT=30
+
+# Gracefully exit if the package has been removed.
+test -x $DAEMON || exit 0
+
+if [ -r /etc/default/$NAME ]; then
+	. /etc/default/$NAME
+fi
+
+if test "$ENABLE_COREFILES" == 1; then
+	ulimit -c unlimited
+fi
+
+if test "$USE_COLLECTDMON" == 1; then
+	_PIDFILE="$COLLECTDMON_PIDFILE"
+else
+	_PIDFILE="$PIDFILE"
+fi
+
+# return:
+#   0 if config is fine
+#   1 if there is a syntax error
+#   2 if there is no configuration
+check_config() {
+	if test ! -e "$CONFIGFILE"; then
+		return 2
+	fi
+	if ! $DAEMON -t -C "$CONFIGFILE"; then
+		return 1
+	fi
+	return 0
+}
+
+d_rotate() {
+	if [ -f /var/lib/collectd.tar.gz ]; then
+		if [ -f /usr/sbin/logrotate ]; then
+			logrotate -f /etc/logrotate-collectd.conf
+		fi
+	fi
+
+	test -f /var/lib/collectd.tar.gz && rm /var/lib/collectd.tar.gz
+	test -d /var/lib/collectd && (cd / && tar czf /var/lib/collectd.tar.gz var/lib/collectd)
+}
+
+# return:
+#   0 if the daemon has been started
+#   1 if the daemon was already running
+#   2 if the daemon could not be started
+#   3 if the daemon was not supposed to be started
+d_start() {
+	d_rotate
+
+	if test "$DISABLE" != 0; then
+		# we get here during restart
+		echo "disabled by /etc/default/$NAME"
+		return 3
+	fi
+
+	if test ! -e "$CONFIGFILE"; then
+		# we get here during restart
+		echo "disabled, no configuration ($CONFIGFILE) found"
+		return 3
+	fi
+
+	check_config
+	rc="$?"
+	if test "$rc" -ne 0; then
+		echo "not starting, configuration error"
+		return 2
+	fi
+
+	if test "$USE_COLLECTDMON" == 1; then
+		start-stop-daemon --start --quiet --oknodo --pidfile "$_PIDFILE" \
+			--exec $COLLECTDMON_DAEMON -- -P "$_PIDFILE" -- -C "$CONFIGFILE" \
+			|| return 2
+	else
+		start-stop-daemon --start --quiet --oknodo --pidfile "$_PIDFILE" \
+			--exec $DAEMON -- -C "$CONFIGFILE" -P "$_PIDFILE" \
+			|| return 2
+	fi
+	return 0
+}
+
+still_running_warning="
+WARNING: $NAME might still be running.
+In large setups it might take some time to write all pending data to
+the disk. You can adjust the waiting time in /etc/default/collectd."
+
+# return:
+#   0 if the daemon has been stopped
+#   1 if the daemon was already stopped
+#   2 if daemon could not be stopped
+d_stop() {
+	PID=$( cat "$_PIDFILE" 2> /dev/null ) || true
+
+	start-stop-daemon --stop --quiet --oknodo --pidfile "$_PIDFILE"
+	rc="$?"
+
+	if test "$rc" -eq 2; then
+		return 2
+	fi
+
+	sleep 1
+	if test -n "$PID" && kill -0 $PID 2> /dev/null; then
+		i=0
+		while kill -0 $PID 2> /dev/null; do
+			i=$(( $i + 2 ))
+			echo -n " ."
+
+			if test $i -gt $MAXWAIT; then
+				echo "$still_running_warning"
+				return 2
+			fi
+
+			sleep 2
+		done
+		return "$rc"
+	fi
+	return "$rc"
+}
+
+# return:
+#   0 if the daemon is running
+#   3 if the daemon is stopped
+d_status(){
+	if test "$USE_COLLECTDMON" == 1; then
+		status $COLLECTDMON_DAEMON
+	else
+		status $DAEMON
+	fi
+}
+
+case "$1" in
+	start)
+		echo -n "Starting $NAME"
+		d_start
+		case "$?" in
+			0|1) echo "." ;;
+			*) exit 1 ;;
+		esac
+		;;
+	stop)
+		echo -n "Stopping $NAME"
+		d_stop
+		case "$?" in
+			0|1) echo "." ;;
+			*) exit 1 ;;
+		esac
+		;;
+	status)
+		d_status
+		;;
+	restart|force-reload)
+		echo -n "Restarting $NAME"
+		check_config
+		rc="$?"
+		if test "$rc" -eq 1; then
+			echo "not restarting, configuration error"
+			exit 1
+		fi
+		d_stop
+		rc="$?"
+		case "$rc" in
+			0|1)
+				sleep 1
+				d_start
+				rc2="$?"
+				case "$rc2" in
+					0|1) echo "." ;;
+					*) exit 1 ;;
+				esac
+				;;
+			*)
+				exit 1
+				;;
+		esac
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2
+		exit 3
+		;;
+esac
+
+# vim: syntax=sh noexpandtab sw=4 ts=4 :
+

--- a/recipes-extended/collectd/collectd/logrotate-collectd.conf
+++ b/recipes-extended/collectd/collectd/logrotate-collectd.conf
@@ -1,0 +1,7 @@
+# see "man logrotate" for details
+# rotate collectd, and keep 7 versions.
+
+/var/lib/collectd.tar.gz {
+	nodateext
+	rotate 7
+}

--- a/recipes-extended/collectd/collectd_5.2.2.bbappend
+++ b/recipes-extended/collectd/collectd_5.2.2.bbappend
@@ -4,6 +4,8 @@ SRC_URI += "file://collectd-perl.patch \
             file://collectd-libstatgrab.patch \
             file://collectd.conf \
             file://collectd-logrotate.conf \
+	    file://logrotate-collectd.conf \
+	    file://collectd.init \
 "
 
 PACKAGECONFIG[sensors] = "--enable-sensors --with-libsensors=yes, \
@@ -11,7 +13,7 @@ PACKAGECONFIG[sensors] = "--enable-sensors --with-libsensors=yes, \
 PACKAGECONFIG[libstatgrab] = "--with-libstatgrab,--without-libstatgrab,libstatgrab,libstatgrab"
 
 DEPENDS += "perl-native"
-RDEPENDS_${PN} += "perl"
+RDEPENDS_${PN} += "logrotate perl"
 
 inherit cpan-base perlnative
 
@@ -57,5 +59,6 @@ do_install_append () {
 
 	install -m 755 -d ${D}${sysconfdir}/logrotate.d
 	install -m 644 ${WORKDIR}/collectd-logrotate.conf ${D}${sysconfdir}/logrotate.d/collectd
+	install -m 644 ${WORKDIR}/logrotate-collectd.conf ${D}${sysconfdir}/logrotate-collectd.conf
 
 }

--- a/recipes-extended/collectd/collectd_5.2.2.bbappend
+++ b/recipes-extended/collectd/collectd_5.2.2.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/collectd:"
 SRC_URI += "file://collectd-perl.patch \
             file://collectd-libstatgrab.patch \
             file://collectd.conf \
+            file://collectd-logrotate.conf \
 "
 
 PACKAGECONFIG[sensors] = "--enable-sensors --with-libsensors=yes, \
@@ -53,4 +54,8 @@ EXTRA_OECONF = " \
 
 do_install_append () {
 	install -m 644 ${WORKDIR}/collectd.conf ${D}/${sysconfdir}/
+
+	install -m 755 -d ${D}${sysconfdir}/logrotate.d
+	install -m 644 ${WORKDIR}/collectd-logrotate.conf ${D}${sysconfdir}/logrotate.d/collectd
+
 }

--- a/recipes-extended/cronie/cronie_%.bbappend
+++ b/recipes-extended/cronie/cronie_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://cronie.volatiles"
+
+do_install_append () {
+	install -d ${D}${sysconfdir}/default/volatiles
+
+	install -m 644 ${WORKDIR}/cronie.volatiles ${D}${sysconfdir}/default/volatiles/97_cronie
+}
+
+CONFFILES_${PN} += "${sysconfdir}/crontab"

--- a/recipes-extended/cronie/files/cronie.volatiles
+++ b/recipes-extended/cronie/files/cronie.volatiles
@@ -1,0 +1,1 @@
+d root crontab 0770 /var/spool/cron none

--- a/recipes-extended/cronie/files/crontab
+++ b/recipes-extended/cronie/files/crontab
@@ -1,0 +1,14 @@
+# /etc/crontab: system-wide crontab
+# Unlike any other crontab you don't have to run the `crontab'
+# command to install the new version when you edit this file
+# and files in /etc/cron.d. These files also have username fields,
+# that none of the other crontabs do.
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+#  m  h  dom mon dow user	command
+  1  *     * * *    root        cd / && run-parts /etc/cron.hourly
+ 30  7     * * *    root        cd / && run-parts /etc/cron.daily
+ 42  7     * * 7    root        cd / && run-parts /etc/cron.weekly
+ 55  7     1 * *    root        cd / && run-parts /etc/cron.monthly

--- a/recipes-extended/logrotate/logrotate/clean-logrotate.cron
+++ b/recipes-extended/logrotate/logrotate/clean-logrotate.cron
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+test -f /var/lib/logrotate.status && rm /var/lib/logrotate.status

--- a/recipes-extended/logrotate/logrotate/logrotate.conf
+++ b/recipes-extended/logrotate/logrotate/logrotate.conf
@@ -1,0 +1,35 @@
+# see "man logrotate" for details
+# rotate log files weekly
+weekly
+
+# keep 4 weeks worth of backlogs
+rotate 4
+
+# create new (empty) log files after rotating old ones
+create
+
+# use date as a suffix of the rotated file
+#dateext
+
+# uncomment this if you want your log files compressed
+#compress
+
+# RPM packages drop log rotation information into this directory
+include /etc/logrotate.d
+
+# no packages own wtmp and btmp -- we'll rotate them here
+#/var/log/wtmp {
+#    monthly
+#    create 0664 root utmp
+#    minsize 1M
+#    rotate 1
+#}
+
+#/var/log/btmp {
+#    missingok
+#    monthly
+#    create 0600 root utmp
+#    rotate 1
+#}
+
+# system-specific logs may be also be configured here.

--- a/recipes-extended/logrotate/logrotate_%.bbappend
+++ b/recipes-extended/logrotate/logrotate_%.bbappend
@@ -1,0 +1,3 @@
+do_install_append () {
+	sed -i -e "s/^dateext$/#dateext/g" ${D}${sysconfdir}/logrotate.conf
+}

--- a/recipes-extended/logrotate/logrotate_%.bbappend
+++ b/recipes-extended/logrotate/logrotate_%.bbappend
@@ -1,3 +1,9 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/logrotate:"
+
+SRC_URI += "file://logrotate.conf"
+SRC_URI += "file://clean-logrotate.cron"
+
 do_install_append () {
-	sed -i -e "s/^dateext$/#dateext/g" ${D}${sysconfdir}/logrotate.conf
+	install -m 644 ${WORKDIR}/logrotate.conf ${D}${sysconfdir}/logrotate.conf
+	install -m 755 ${WORKDIR}/clean-logrotate.cron ${D}${sysconfdir}/cron.daily/clean-logrotate
 }

--- a/recipes-httpd/nginx/files/nginx-logrotate.conf
+++ b/recipes-httpd/nginx/files/nginx-logrotate.conf
@@ -2,6 +2,7 @@
     missingok
     sharedscripts
     compress
+    size 1M
     postrotate
         test ! -r /run/nginx/nginx.pid || kill -USR1 `cat /run/nginx/nginx.pid`
     endscript

--- a/recipes-httpd/nginx/files/nginx-logrotate.conf
+++ b/recipes-httpd/nginx/files/nginx-logrotate.conf
@@ -1,0 +1,8 @@
+/var/log/nginx/*log {
+    missingok
+    sharedscripts
+    compress
+    postrotate
+        test ! -r /run/nginx/nginx.pid || kill -USR1 `cat /run/nginx/nginx.pid`
+    endscript
+}

--- a/recipes-httpd/nginx/nginx_%.bbappend
+++ b/recipes-httpd/nginx/nginx_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI += "http://internal.rdm.local/blobs/nginx-legal-0.2.tar.gz;name=legal \
 	http://internal.rdm.local/blobs/nginx-manual-0.4.tar.gz;name=manual \
 	http://internal.rdm.local/blobs/nginx-html-0.2.tar.gz;name=html \
 	file://nginx-varlib.volatiles \
+	file://nginx-logrotate.conf \
 "
 
 SRC_URI[legal.md5sum] = "ccb221827f2bcd827cca8db6a3d14d70"
@@ -57,4 +58,7 @@ do_install_append () {
 	install -o www -g www-data -m 0755 -t ${D}${localstatedir}/www/localhost/manual/ ${WORKDIR}/manual/*
 
 	install -m 644 ${WORKDIR}/nginx-varlib.volatiles ${D}${sysconfdir}/default/volatiles/98_nginx_varlib
+
+	install -m 755 -d ${D}${sysconfdir}/logrotate.d
+	install -m 644 ${WORKDIR}/nginx-logrotate.conf ${D}${sysconfdir}/logrotate.d/nginx
 }

--- a/recipes-rdm/fb-init/fb-init_svn.bb
+++ b/recipes-rdm/fb-init/fb-init_svn.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN} = "fbset imagemagick liberation-fonts"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_FrameBuffer/trunk/;protocol=http;module=IEBF;rev=4072"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_FrameBuffer/trunk/;protocol=http;module=IEBF;rev=4590"
 S = "${WORKDIR}/IEBF/src"
 
 inherit update-rc.d

--- a/recipes-rdm/fb-init/fb-init_svn.bb
+++ b/recipes-rdm/fb-init/fb-init_svn.bb
@@ -37,4 +37,4 @@ do_install() {
 FILES_${PN} += "/opt/rdm/fb"
 
 INITSCRIPT_NAME = "init_fb"
-INITSCRIPT_PARAMS = "start 99 5 S. stop 20 0 1 6 ."
+INITSCRIPT_PARAMS = "start 99 5 . stop 20 0 1 6 ."

--- a/recipes-rdm/hp-blob/files/dfservice-log.run
+++ b/recipes-rdm/hp-blob/files/dfservice-log.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec multilog t /var/log/daemontools/dfservice

--- a/recipes-rdm/hp-blob/files/dfservice.run
+++ b/recipes-rdm/hp-blob/files/dfservice.run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec start-stop-daemon -S --pidfile /run/dfservice.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec @HOMEPILOT_BASE@/bin/dfservice
+exec start-stop-daemon -S --pidfile /run/dfservice.pid --make-pidfile --chuid @HOMEPILOT_USER@ --exec @HOMEPILOT_BASE@/bin/dfservice 2>&1

--- a/recipes-rdm/hp-blob/hp-blob_svn.bb
+++ b/recipes-rdm/hp-blob/hp-blob_svn.bb
@@ -18,6 +18,7 @@ HPREV="4517"
 PV = "4.0.${HPREV}"
 SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_Blob/trunk/;protocol=http;module=HomePilot_Blob;rev=${HPREV} \
                 file://dfservice.run \
+                file://dfservice-log.run \
                 file://homepilot.run \
                 file://homepilot-log.run \
                 file://homepilot.sh \
@@ -74,6 +75,7 @@ do_install() {
 	# 1 Create all the folders
 	install -d ${D}${SVC_SERVICES}/homepilot-network-manager
 	install -d ${D}${SVC_SERVICES}/dfservice
+	install -d ${D}${SVC_SERVICES}/dfservice/log
 	install -d ${D}${SVC_SERVICES}/homepilot
 	install -d ${D}${SVC_SERVICES}/homepilot/log
 	install -d ${D}${SVC_SERVICES}/jetty
@@ -83,6 +85,7 @@ do_install() {
 	# 2 Move all the run-files
 	install -m 0755 ${WORKDIR}/homepilot-network-manager.run ${D}${SVC_SERVICES}/homepilot-network-manager/run
 	install -m 0755 ${WORKDIR}/dfservice.run ${D}${SVC_SERVICES}/dfservice/run
+	install -m 0755 ${WORKDIR}/dfservice-log.run ${D}${SVC_SERVICES}/dfservice/log/run
 	install -m 0755 ${WORKDIR}/homepilot.run ${D}${SVC_SERVICES}/homepilot/run
 	install -m 0755 ${WORKDIR}/homepilot.sh ${D}${INST_DEST_PREFIX}/bin/homepilot
 	install -m 0755 ${WORKDIR}/homepilot-log.run ${D}${SVC_SERVICES}/homepilot/log/run

--- a/recipes-rdm/hp2sm/files/hp2sm-log.run
+++ b/recipes-rdm/hp2sm/files/hp2sm-log.run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec multilog t /var/log/daemontools/hp2sm

--- a/recipes-rdm/hp2sm/files/hp2sm.run
+++ b/recipes-rdm/hp2sm/files/hp2sm.run
@@ -10,4 +10,4 @@ OPTIONS="--env production --port ${PLACK_PORT} ${PLACK_APP} "
 PIDFILE="/var/run/$NAME.pid"
 
 export SYSTEM_IMAGE_UPDATE_DIR=/data/.update
-exec start-stop-daemon -m --start --quiet --pidfile "$PIDFILE" --exec plackup -- $OPTIONS
+exec start-stop-daemon -m --start --quiet --pidfile "$PIDFILE" --exec plackup -- $OPTIONS 2>&1

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -20,6 +20,7 @@ PV = "0.1"
 
 SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4603"
 SRC_URI += "file://hp2sm.run"
+SRC_URI += "file://hp2sm-log.run"
 S = "${WORKDIR}/hp2sm/src"
 
 SERVICE_ROOT = "${sysconfdir}/daemontools/service"
@@ -28,9 +29,11 @@ HP2SM_SERVICE_DIR = "${SERVICE_ROOT}/hp2sm"
 do_install() {
 	#create init.d directory
 	install -d ${D}${HP2SM_SERVICE_DIR}
+	install -d ${D}${HP2SM_SERVICE_DIR}/log
 	
 	#install svc run script and make it executable
 	install -m 0755 ${WORKDIR}/hp2sm.run ${D}${HP2SM_SERVICE_DIR}/run
+	install -m 0755 ${WORKDIR}/hp2sm-log.run ${D}${HP2SM_SERVICE_DIR}/log/run
 	
 	#create directory for source
 	install -d ${D}/opt/rdm/hp2sm

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4598"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4603"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 

--- a/recipes-rdm/hp2sm/hp2sm_svn.bb
+++ b/recipes-rdm/hp2sm/hp2sm_svn.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "test-memory-cycle-perl test-leaktrace-perl"
 
 PV = "0.1"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4578"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_ServiceMonitor/trunk;protocol=http;module=hp2sm;rev=4598"
 SRC_URI += "file://hp2sm.run"
 S = "${WORKDIR}/hp2sm/src"
 

--- a/recipes-rdm/images/rdm.inc
+++ b/recipes-rdm/images/rdm.inc
@@ -1,5 +1,6 @@
 RDM_BASE_INSTALL = "hp2sm \
 	alsa-utils \
+	cronie \
 	init-iecset \
 	e2fsprogs \
 	e2fsprogs-tune2fs \

--- a/recipes-rdm/ledctrl/ledctrl/ledbootup.sh
+++ b/recipes-rdm/ledctrl/ledctrl/ledbootup.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # Frank measured >45 seconds between LED turned into ready state and every application is runnning
-# sleep 90 seconds just to be sure
+# sleep 120 seconds just to be sure
 
-sleep 90s
+sleep 120s
 
 echo none >/sys/class/leds/boot/trigger
 echo 0 >/sys/class/leds/boot/brightness

--- a/recipes-rdm/service-df/service-df_svn.bb
+++ b/recipes-rdm/service-df/service-df_svn.bb
@@ -9,7 +9,7 @@ DEPENDS = "libxml2 libftdi"
 
 PV = "1.2.0"
 
-SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_DuoFern_Service/trunk/;protocol=http;module=DuoFern_Service;rev=4519"
+SRC_URI = "svn://192.168.1.186/svn/EW_Prj/001/HP_DuoFern_Service/trunk/;protocol=http;module=DuoFern_Service;rev=4605"
 
 S = "${WORKDIR}/DuoFern_Service"
 

--- a/recipes-rdm/system-image/files/run
+++ b/recipes-rdm/system-image/files/run
@@ -4,11 +4,6 @@ test -f /tmp/sysimg_update.once || rm -rf /data/.update/*
 test -f /tmp/sysimg_update.once || sleep 5m
 touch /tmp/sysimg_update.once
 
-if [ -f /var/log/sysimg_update.log -a `stat -c "%s" /var/log/sysimg_update.log` -gt 1048576 ]
-then
-    mv /var/log/sysimg_update.log /var/log/sysimg_update.log.old
-    xz /var/log/sysimg_update.log.old
-fi
 export SYSTEM_IMAGE_UPDATE_DIR=/data/.update
 export SYSTEM_IMAGE_UPDATE_FLASH_DIR=/data/.flashimg
 exec /usr/bin/sysimg_update

--- a/recipes-rdm/system-image/files/system-image-update-logrotate.conf
+++ b/recipes-rdm/system-image/files/system-image-update-logrotate.conf
@@ -1,0 +1,5 @@
+/var/log/sysimg_update.log /var/log/sysimg_update.error {
+    missingok
+    compress
+    size 1M
+}

--- a/recipes-rdm/system-image/system-image-update_git.bb
+++ b/recipes-rdm/system-image/system-image-update_git.bb
@@ -14,6 +14,7 @@ file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 SRC_URI = "git://github.com/rehsack/System-Image-Update.git;rev=5d15d24e50ec91ad86a170887b07b70d88b4495e \
            file://run \
 	   file://sysimg_update.json \
+	   file://system-image-update-logrotate.conf \
 "
 
 RDEPENDS_${PN} += "archive-peek-libarchive-perl"
@@ -52,6 +53,9 @@ do_install_append() {
 
     install -d ${D}${SYSUPDT_SERVICE_DIR}
     install -m 0755 ${WORKDIR}/run ${D}${SYSUPDT_SERVICE_DIR}/run
+
+    install -m 755 -d ${D}${sysconfdir}/logrotate.d
+    install -m 644 ${WORKDIR}/system-image-update-logrotate.conf ${D}${sysconfdir}/logrotate.d/system-image-update
 }
 
 FILES_${PN} += "${sysconfdir}"

--- a/recipes-xbmc/xbmc/xbmc_14.bb
+++ b/recipes-xbmc/xbmc/xbmc_14.bb
@@ -7,7 +7,7 @@ DEPENDS_append_mx6 = " virtual/kernel virtual/libgles2 virtual/egl libfslvpuwrap
 
 SRC_URI = "git://github.com/xbmc/xbmc.git;rev=${SRCREV};branch=${SRCBRANCH}"
 SRCBRANCH = "Helix"
-SRCREV = "38e404661b56ea5c12460ca1a4079eef9c98d233"
+SRCREV = "7cc53a9a3da77869d1d5d3d3d9971b4bd1641b50"
 
 INC_PR = "r1"
 PR = "${INC_PR}.1"


### PR DESCRIPTION
- add libpam to openvpn dependencies
- update kodi to 14.2
- disable syslog for collectd
- sleep 120 seconds before setting ledbootup into ready state
- add cronie
- add logrotate configuration for collectd
- add logrotate configuration for nginx
- add logrotate configuration for system-image-update and remove custom log rotation on startup
- add logrotate configuration for collectd and run logrotate on startup
- add hp2sm log
- add dfservice log
- improve logrotate configuration
    - disable dateext to use a number instead of a date extension
    - set size to 1M
    - disable log rotation for btmp and wtmp
    - add daily cron job to remove logrotate state file
- update hp2sm
    - improve ssh key management
        - create non-existing ~/.ssh directory
    - rename XBMC to XBMC/Kodi
    - remove template relic
    - add log files for collectd
    - Style harmonization using Perl::Tidy
- update fb-init
    - Create pictures only if IP-Address changed!
    - Fixed minor bugs (waiting text, copy framebuffer-picture)
    - Fixed Fontsize
- fix fb-init startup
- update service-df
    - bugfix for uid and add forgotten lock command