### PR TITLE
4.0.27

### DIFF
--- a/recipes-bsp/u-boot/u-boot-curie_2013.04.bb
+++ b/recipes-bsp/u-boot/u-boot-curie_2013.04.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=1707d6db1d42237583f50183a5651ecb"
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
 SRCBRANCH = "curie_v2013.04_3.10.17"
-SRC_URI = "git://github.com/rdm-dev/uboot-curie.git;branch=${SRCBRANCH};rev=20d0e998b0978f87d440f1c46b76116d11ba3128 \
+SRC_URI = "git://github.com/rdm-dev/uboot-curie.git;branch=${SRCBRANCH};rev=f0ef55031b9cff41ac2cea37a9955672ed6a051d \
            file://bootsettings.patch \
 	   "
 

--- a/recipes-kernel/linux/linux-curie_3.10.80.bb
+++ b/recipes-kernel/linux/linux-curie_3.10.80.bb
@@ -9,7 +9,7 @@ require recipes-kernel/linux/linux-dtb.inc
 
 DEPENDS += "lzop-native bc-native u-boot-curie"
 
-REV="294d5af92ed392ade42bdf551ae29f5768bd2540"
+REV="55b7040f12d6589d5195a85a6d0c7a7b692bd78b"
 SRCREPO="rdm-dev"
 SRCBRANCH = "curie_3.10.84_1.0.0_ga"
 LOCALVERSION = "+curie"


### PR DESCRIPTION
- update uboot-curie to support rev-e
    - Port to RevE with the watchdog reset pin support
- update linux-curie to support rev-e and to pass HDMI certification
    - dt: Change the params to pass HDMI certification
    - mxc_hdmi: don't require CEA mode
    - Initialize the Watchdog reset pin in RevE