### PR TITLE
distro/rdm.conf: remove version-picking of openjdk-8

### DIFF
--- a/conf/distro/rdm.conf
+++ b/conf/distro/rdm.conf
@@ -67,13 +67,9 @@ PREFERRED_PROVIDER_virtual/javac-native = "openjdk-8-native"
 PREFERRED_PROVIDER_java2-runtime = "openjre-8"
 PREFERRED_PROVIDER_java2-vm = "openjre-8"
 
-PREFERRED_VERSION_openjdk-8-native = "72b00"
-PREFERRED_VERSION_openjdk-8 = "72b00"
-PREFERRED_VERSION_openjre-8 = "72b00"
-
 LICENSE_FLAGS_WHITELIST += " commercial"
 
-GCCVERSION = "4.9.3"
+GCCVERSION = "4.9.%"
 
 require conf/distro/poky.conf
 


### PR DESCRIPTION
Since there is only one version of openjdk-8 available, avoid insane
picking a probably outdated one.

Signed-off-by: Jens Rehsack <sno@netbsd.org>