### PR TITLE
v8: rewrite recipe's to rely on git repositories

### DIFF
--- a/recipes-www/v8/v8.inc
+++ b/recipes-www/v8/v8.inc
@@ -48,6 +48,8 @@ do_patch_for_rpath () {
 
 do_patch[postfuncs] += " do_patch_for_rpath "
 
+CLEANBROKEN = "1"
+
 do_compile () {
     export LD="${CXX}"
     export LINK="${CXX}"

--- a/recipes-www/v8/v8/v8_3.17.16-weird-dirty-serguei.patch
+++ b/recipes-www/v8/v8/v8_3.17.16-weird-dirty-serguei.patch
@@ -1,0 +1,846 @@
+diff --git a/Makefile b/Makefile
+index 8e550d0..9b6e779 100644
+--- a/Makefile
++++ b/Makefile
+@@ -95,6 +95,11 @@ ifeq ($(vfp3), off)
+ else
+   GYPFLAGS += -Dv8_can_use_vfp3_instructions=true -Darm_fpu=vfpv3
+ endif
++ifeq ($(vfp3), off)
++  ifeq ($(vfp2), off)
++    GYPFLAGS += -Darm_fpu=none
++  endif
++endif
+ # debuggersupport=off
+ ifeq ($(debuggersupport), off)
+   GYPFLAGS += -Dv8_enable_debugger_support=0
+diff --git a/build/standalone.gypi b/build/standalone.gypi
+index 749755c..f506659 100644
+--- a/build/standalone.gypi
++++ b/build/standalone.gypi
+@@ -95,7 +95,7 @@
+     ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris" \
+        or OS=="netbsd"', {
+       'target_defaults': {
+-        'cflags': [ '-Wall', '<(werror)', '-W', '-Wno-unused-parameter',
++        'cflags': [ '-Wall', '<(werror)', '-W', '-Wno-unused-parameter', '-Wno-unused-local-typedefs',
+                     '-Wnon-virtual-dtor', '-pthread', '-fno-rtti',
+                     '-fno-exceptions', '-pedantic' ],
+         'ldflags': [ '-pthread', ],
+diff --git a/include/v8.h b/include/v8.h
+index 9adb1c0..b95e37b 100644
+--- a/include/v8.h
++++ b/include/v8.h
+@@ -279,6 +279,10 @@ template <class T> class Handle {
+   }
+ 
+  private:
++  template <class S> friend class Handle;
++  template <class S> friend class Local;
++  template <class S> friend class Persistent;
++
+   T* val_;
+ };
+ 
+@@ -351,6 +355,16 @@ template <class T> class Persistent : public Handle<T> {
+    */
+   V8_INLINE(Persistent());
+ 
++  template <class S> V8_INLINE(Persistent(Isolate* isolate, Handle<S> handle))
++    : Handle<T>(*New(isolate, handle)) {
++    /**
++     * This check fails when trying to convert between incompatible
++     * handles. For example, converting from a Handle<String> to a
++     * Handle<Number>.
++     */
++    TYPE_CHECK(T, S);
++  }
++
+   /**
+    * Creates a persistent handle for the same storage cell as the
+    * specified handle.  This constructor allows you to pass persistent
+@@ -395,7 +409,7 @@ template <class T> class Persistent : public Handle<T> {
+   }
+ 
+   /** Deprecated. Use Isolate version instead. */
+-  V8_DEPRECATED(static Persistent<T> New(Handle<T> that));
++  V8_INLINE(static Persistent<T> New(Handle<T> that));
+ 
+   /**
+    * Creates a new persistent handle for an existing local or persistent handle.
+@@ -413,6 +427,12 @@ template <class T> class Persistent : public Handle<T> {
+    */
+   V8_INLINE(void Dispose(Isolate* isolate));
+ 
++
++  V8_INLINE(void Reset());
++
++  template <class S>
++  V8_INLINE(void Reset(Isolate* isolate, const Handle<S> &that));
++
+   /** Deprecated. Use Isolate version instead. */
+   V8_DEPRECATED(void MakeWeak(void* parameters,
+                               WeakReferenceCallback callback));
+@@ -1091,6 +1111,7 @@ class V8EXPORT Boolean : public Primitive {
+  public:
+   bool Value() const;
+   V8_INLINE(static Handle<Boolean> New(bool value));
++  V8_INLINE(static Handle<Boolean> New(Isolate* isolate, bool value));
+ };
+ 
+ 
+@@ -1307,12 +1328,15 @@ class V8EXPORT String : public Primitive {
+    * the function calls 'strlen' to determine the buffer length.
+    */
+   static Local<String> New(const char* data, int length = -1);
++  static Local<String> New(Isolate* isolate, const char* data, int length = -1);
+ 
+   /** Allocates a new string from 16-bit character codes.*/
+   static Local<String> New(const uint16_t* data, int length = -1);
++  static Local<String> New(Isolate* isolate, const uint16_t* data, int length = -1);
+ 
+   /** Creates a symbol. Returns one if it exists already.*/
+   static Local<String> NewSymbol(const char* data, int length = -1);
++  static Local<String> NewSymbol(Isolate* isolate, const char* data, int length = -1);
+ 
+   /**
+    * Creates a new string by concatenating the left and the right strings
+@@ -1329,6 +1353,7 @@ class V8EXPORT String : public Primitive {
+    * destructor of the external string resource.
+    */
+   static Local<String> NewExternal(ExternalStringResource* resource);
++  static Local<String> NewExternal(Isolate* isolate, ExternalStringResource* resource);
+ 
+   /**
+    * Associate an external string resource with this string by transforming it
+@@ -1350,6 +1375,7 @@ class V8EXPORT String : public Primitive {
+    * destructor of the external string resource.
+    */
+   static Local<String> NewExternal(ExternalAsciiStringResource* resource);
++  static Local<String> NewExternal(Isolate* isolate, ExternalAsciiStringResource* resource);
+ 
+   /**
+    * Associate an external string resource with this string by transforming it
+@@ -1369,9 +1395,11 @@ class V8EXPORT String : public Primitive {
+ 
+   /** Creates an undetectable string from the supplied ASCII or UTF-8 data.*/
+   static Local<String> NewUndetectable(const char* data, int length = -1);
++  static Local<String> NewUndetectable(Isolate* isolate, const char* data, int length = -1);
+ 
+   /** Creates an undetectable string from the supplied 16-bit character codes.*/
+   static Local<String> NewUndetectable(const uint16_t* data, int length = -1);
++  static Local<String> NewUndetectable(Isolate* isolate, const uint16_t* data, int length = -1);
+ 
+   /**
+    * Converts an object to a UTF-8-encoded character array.  Useful if
+@@ -1456,6 +1484,7 @@ class V8EXPORT Number : public Primitive {
+  public:
+   double Value() const;
+   static Local<Number> New(double value);
++  static Local<Number> New(Isolate* isolate, double value);
+   V8_INLINE(static Number* Cast(v8::Value* obj));
+  private:
+   Number();
+@@ -1470,8 +1499,16 @@ class V8EXPORT Integer : public Number {
+  public:
+   static Local<Integer> New(int32_t value);
+   static Local<Integer> NewFromUnsigned(uint32_t value);
+-  static Local<Integer> New(int32_t value, Isolate*);
+-  static Local<Integer> NewFromUnsigned(uint32_t value, Isolate*);
++
++  V8_INLINE(static Local<Integer> New(int32_t value, Isolate* isolate)) {
++    return New(isolate, value);
++  };
++  V8_INLINE(static Local<Integer> NewFromUnsigned(uint32_t value, Isolate* isolate)) {
++    return NewFromUnsigned(isolate, value);
++  };
++
++  static Local<Integer> New(Isolate* isolate, int32_t value);
++  static Local<Integer> NewFromUnsigned(Isolate* isolate, uint32_t value);
+   int64_t Value() const;
+   V8_INLINE(static Integer* Cast(v8::Value* obj));
+  private:
+@@ -1814,6 +1851,7 @@ class V8EXPORT Object : public Value {
+   Local<Value> CallAsConstructor(int argc, Handle<Value> argv[]);
+ 
+   static Local<Object> New();
++  static Local<Object> New(Isolate* isolate);
+   V8_INLINE(static Object* Cast(Value* obj));
+ 
+  private:
+@@ -1842,6 +1880,7 @@ class V8EXPORT Array : public Object {
+    * is negative the returned array will have length 0.
+    */
+   static Local<Array> New(int length = 0);
++  static Local<Array> New(Isolate* isolate, int length = 0);
+ 
+   V8_INLINE(static Array* Cast(Value* obj));
+  private:
+@@ -1896,6 +1935,7 @@ class V8EXPORT Function : public Object {
+ class V8EXPORT Date : public Object {
+  public:
+   static Local<Value> New(double time);
++  static Local<Value> New(Isolate* isolate, double time);
+ 
+   /**
+    * A specialization of Value::NumberValue that is more efficient
+@@ -1930,6 +1970,7 @@ class V8EXPORT Date : public Object {
+ class V8EXPORT NumberObject : public Object {
+  public:
+   static Local<Value> New(double value);
++  static Local<Value> New(Isolate* isolate, double value);
+ 
+   /**
+    * Returns the Number held by the object.
+@@ -2034,6 +2075,7 @@ class V8EXPORT RegExp : public Object {
+ class V8EXPORT External : public Value {
+  public:
+   static Local<External> New(void* value);
++  static Local<External> New(Isolate* isolate, void* value);
+   V8_INLINE(static External* Cast(Value* obj));
+   void* Value() const;
+  private:
+@@ -2052,6 +2094,7 @@ class V8EXPORT Template : public Data {
+   /** Adds a property to each instance created by this template.*/
+   void Set(Handle<String> name, Handle<Data> value,
+            PropertyAttribute attributes = None);
++  V8_INLINE(void Set(Isolate* isolate, const char* name, Handle<Data> value));
+   V8_INLINE(void Set(const char* name, Handle<Data> value));
+  private:
+   Template();
+@@ -2327,6 +2370,12 @@ class V8EXPORT FunctionTemplate : public Template {
+       Handle<Value> data = Handle<Value>(),
+       Handle<Signature> signature = Handle<Signature>(),
+       int length = 0);
++  static Local<FunctionTemplate> New(
++      Isolate* isolate,
++      InvocationCallback callback = 0,
++      Handle<Value> data = Handle<Value>(),
++      Handle<Signature> signature = Handle<Signature>(),
++      int length = 0);
+   /** Returns the unique function instance in the current execution context.*/
+   Local<Function> GetFunction();
+ 
+@@ -2418,6 +2467,7 @@ class V8EXPORT ObjectTemplate : public Template {
+  public:
+   /** Creates an ObjectTemplate. */
+   static Local<ObjectTemplate> New();
++  static Local<ObjectTemplate> New(Isolate* isolate);
+ 
+   /** Creates a new instance of this template.*/
+   Local<Object> NewInstance();
+@@ -2564,7 +2614,7 @@ class V8EXPORT ObjectTemplate : public Template {
+ 
+  private:
+   ObjectTemplate();
+-  static Local<ObjectTemplate> New(Handle<FunctionTemplate> constructor);
++  static Local<ObjectTemplate> New(Isolate* isolate, Handle<FunctionTemplate> constructor);
+   friend class FunctionTemplate;
+ };
+ 
+@@ -2799,6 +2849,7 @@ typedef void (*MessageCallback)(Handle<Message> message, Handle<Value> error);
+  * has been handled does it become legal to invoke JavaScript operations.
+  */
+ Handle<Value> V8EXPORT ThrowException(Handle<Value> exception);
++Handle<Value> V8EXPORT ThrowException(Isolate* isolate, Handle<Value> exception);
+ 
+ /**
+  * Create new error objects by calling the corresponding error object
+@@ -3886,6 +3937,11 @@ class V8EXPORT Context {
+       ExtensionConfiguration* extensions = NULL,
+       Handle<ObjectTemplate> global_template = Handle<ObjectTemplate>(),
+       Handle<Value> global_object = Handle<Value>());
++  static Persistent<Context> New(
++      Isolate* isolate,
++      ExtensionConfiguration* extensions = NULL,
++      Handle<ObjectTemplate> global_template = Handle<ObjectTemplate>(),
++      Handle<Value> global_object = Handle<Value>());
+ 
+   /** Returns the last entered context. */
+   static Local<Context> GetEntered();
+@@ -4525,6 +4581,19 @@ void Persistent<T>::Dispose(Isolate* isolate) {
+                     reinterpret_cast<internal::Object**>(**this));
+ }
+ 
++template <class T>
++void Persistent<T>::Reset() {
++  Dispose(Isolate::GetCurrent());
++}
++
++template <class T>
++template <class S>
++void Persistent<T>::Reset(Isolate* isolate, const Handle<S> &value) {
++  Reset();
++  if (value.IsEmpty()) return;
++  this->val_ = *New(isolate, value);
++}
++
+ 
+ template <class T>
+ Persistent<T>::Persistent() : Handle<T>() { }
+@@ -4695,16 +4764,22 @@ Handle<Integer> ScriptOrigin::ResourceColumnOffset() const {
+ }
+ 
+ 
++Handle<Boolean> Boolean::New(Isolate* isolate, bool value) {
++  return value ? True(isolate) : False(isolate);
++}
++
+ Handle<Boolean> Boolean::New(bool value) {
+   return value ? True() : False();
+ }
+ 
++void Template::Set(Isolate* isolate, const char* name, v8::Handle<Data> value) {
++  Set(v8::String::New(isolate, name), value);
++}
+ 
+ void Template::Set(const char* name, v8::Handle<Data> value) {
+   Set(v8::String::New(name), value);
+ }
+ 
+-
+ Local<Value> Object::GetInternalField(int index) {
+ #ifndef V8_ENABLE_CHECKS
+   typedef internal::Object O;
+diff --git a/src/api.cc b/src/api.cc
+index 65663ba..d447f79 100644
+--- a/src/api.cc
++++ b/src/api.cc
+@@ -486,9 +486,13 @@ void V8::SetFlagsFromCommandLine(int* argc, char** argv, bool remove_flags) {
+   i::FlagList::SetFlagsFromCommandLine(argc, argv, remove_flags);
+ }
+ 
+-
+ v8::Handle<Value> ThrowException(v8::Handle<v8::Value> value) {
+-  i::Isolate* isolate = i::Isolate::Current();
++    i::Isolate* isolate = i::Isolate::Current();
++    return ThrowException(reinterpret_cast<Isolate*>(isolate), value);
++}
++
++v8::Handle<Value> ThrowException(Isolate* _isolate, v8::Handle<v8::Value> value) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   if (IsDeadCheck(isolate, "v8::ThrowException()")) {
+     return v8::Handle<Value>();
+   }
+@@ -941,6 +945,7 @@ void Template::Set(v8::Handle<String> name, v8::Handle<Data> value,
+   if (IsDeadCheck(isolate, "v8::Template::Set()")) return;
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
++  Isolate* v8_isolate = reinterpret_cast<Isolate*>(isolate);
+   i::Handle<i::Object> list(Utils::OpenHandle(this)->property_list(), isolate);
+   if (list->IsUndefined()) {
+     list = NeanderArray().value();
+@@ -949,7 +954,7 @@ void Template::Set(v8::Handle<String> name, v8::Handle<Data> value,
+   NeanderArray array(list);
+   array.add(Utils::OpenHandle(*name));
+   array.add(Utils::OpenHandle(*value));
+-  array.add(Utils::OpenHandle(*v8::Integer::New(attribute)));
++  array.add(Utils::OpenHandle(*v8::Integer::New(v8_isolate, attribute)));
+ }
+ 
+ 
+@@ -967,10 +972,11 @@ Local<ObjectTemplate> FunctionTemplate::PrototypeTemplate() {
+     return Local<ObjectTemplate>();
+   }
+   ENTER_V8(isolate);
++  Isolate* v8_isolate = reinterpret_cast<Isolate*>(isolate);
+   i::Handle<i::Object> result(Utils::OpenHandle(this)->prototype_template(),
+                               isolate);
+   if (result->IsUndefined()) {
+-    result = Utils::OpenHandle(*ObjectTemplate::New());
++    result = Utils::OpenHandle(*ObjectTemplate::New(v8_isolate));
+     Utils::OpenHandle(this)->set_prototype_template(*result);
+   }
+   return Local<ObjectTemplate>(ToApi<ObjectTemplate>(result));
+@@ -984,10 +990,15 @@ void FunctionTemplate::Inherit(v8::Handle<FunctionTemplate> value) {
+   Utils::OpenHandle(this)->set_parent_template(*Utils::OpenHandle(*value));
+ }
+ 
+-
+ Local<FunctionTemplate> FunctionTemplate::New(InvocationCallback callback,
+     v8::Handle<Value> data, v8::Handle<Signature> signature, int length) {
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), callback, data, signature, length);
++}
++
++Local<FunctionTemplate> FunctionTemplate::New(Isolate* _isolate, InvocationCallback callback,
++    v8::Handle<Value> data, v8::Handle<Signature> signature, int length) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::FunctionTemplate::New()");
+   LOG_API(isolate, "FunctionTemplate::New");
+   ENTER_V8(isolate);
+@@ -1279,9 +1290,10 @@ Local<ObjectTemplate> FunctionTemplate::InstanceTemplate() {
+       || EmptyCheck("v8::FunctionTemplate::InstanceTemplate()", this))
+     return Local<ObjectTemplate>();
+   ENTER_V8(isolate);
++  Isolate* v8_isolate = reinterpret_cast<Isolate*>(isolate);
+   if (Utils::OpenHandle(this)->instance_template()->IsUndefined()) {
+     Local<ObjectTemplate> templ =
+-        ObjectTemplate::New(v8::Handle<FunctionTemplate>(this));
++        ObjectTemplate::New(v8_isolate, v8::Handle<FunctionTemplate>(this));
+     Utils::OpenHandle(this)->set_instance_template(*Utils::OpenHandle(*templ));
+   }
+   i::Handle<i::ObjectTemplateInfo> result(i::ObjectTemplateInfo::cast(
+@@ -1411,15 +1423,19 @@ void FunctionTemplate::SetInstanceCallAsFunctionHandler(
+ 
+ // --- O b j e c t T e m p l a t e ---
+ 
+-
+ Local<ObjectTemplate> ObjectTemplate::New() {
+-  return New(Local<FunctionTemplate>());
++  i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate));
++}
++
++Local<ObjectTemplate> ObjectTemplate::New(Isolate* _isolate) {
++  return New(_isolate, Local<FunctionTemplate>());
+ }
+ 
+ 
+-Local<ObjectTemplate> ObjectTemplate::New(
++Local<ObjectTemplate> ObjectTemplate::New(Isolate* _isolate,
+       v8::Handle<FunctionTemplate> constructor) {
+-  i::Isolate* isolate = i::Isolate::Current();
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   if (IsDeadCheck(isolate, "v8::ObjectTemplate::New()")) {
+     return Local<ObjectTemplate>();
+   }
+@@ -1440,9 +1456,9 @@ Local<ObjectTemplate> ObjectTemplate::New(
+ 
+ // Ensure that the object template has a constructor.  If no
+ // constructor is available we create one.
+-static void EnsureConstructor(ObjectTemplate* object_template) {
++static void EnsureConstructor(i::Isolate* isolate, ObjectTemplate* object_template) {
+   if (Utils::OpenHandle(object_template)->constructor()->IsUndefined()) {
+-    Local<FunctionTemplate> templ = FunctionTemplate::New();
++    Local<FunctionTemplate> templ = FunctionTemplate::New(reinterpret_cast<Isolate*>(isolate));
+     i::Handle<i::FunctionTemplateInfo> constructor = Utils::OpenHandle(*templ);
+     constructor->set_instance_template(*Utils::OpenHandle(object_template));
+     Utils::OpenHandle(object_template)->set_constructor(*constructor);
+@@ -1474,7 +1490,7 @@ void ObjectTemplate::SetAccessor(v8::Handle<String> name,
+   if (IsDeadCheck(isolate, "v8::ObjectTemplate::SetAccessor()")) return;
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
+-  EnsureConstructor(this);
++  EnsureConstructor(isolate, this);
+   i::FunctionTemplateInfo* constructor =
+       i::FunctionTemplateInfo::cast(Utils::OpenHandle(this)->constructor());
+   i::Handle<i::FunctionTemplateInfo> cons(constructor);
+@@ -1494,7 +1510,7 @@ bool ObjectTemplate::SetAccessor(Handle<String> name,
+   if (IsDeadCheck(isolate, "v8::ObjectTemplate::SetAccessor()")) return false;
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
+-  EnsureConstructor(this);
++  EnsureConstructor(isolate, this);
+   i::FunctionTemplateInfo* constructor =
+       i::FunctionTemplateInfo::cast(Utils::OpenHandle(this)->constructor());
+   i::Handle<i::FunctionTemplateInfo> cons(constructor);
+@@ -1518,7 +1534,7 @@ void ObjectTemplate::SetNamedPropertyHandler(NamedPropertyGetter getter,
+   }
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
+-  EnsureConstructor(this);
++  EnsureConstructor(isolate, this);
+   i::FunctionTemplateInfo* constructor =
+       i::FunctionTemplateInfo::cast(Utils::OpenHandle(this)->constructor());
+   i::Handle<i::FunctionTemplateInfo> cons(constructor);
+@@ -1536,7 +1552,7 @@ void ObjectTemplate::MarkAsUndetectable() {
+   if (IsDeadCheck(isolate, "v8::ObjectTemplate::MarkAsUndetectable()")) return;
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
+-  EnsureConstructor(this);
++  EnsureConstructor(isolate, this);
+   i::FunctionTemplateInfo* constructor =
+       i::FunctionTemplateInfo::cast(Utils::OpenHandle(this)->constructor());
+   i::Handle<i::FunctionTemplateInfo> cons(constructor);
+@@ -1555,7 +1571,7 @@ void ObjectTemplate::SetAccessCheckCallbacks(
+   }
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
+-  EnsureConstructor(this);
++  EnsureConstructor(isolate, this);
+ 
+   i::Handle<i::Struct> struct_info =
+       isolate->factory()->NewStruct(i::ACCESS_CHECK_INFO_TYPE);
+@@ -1589,7 +1605,7 @@ void ObjectTemplate::SetIndexedPropertyHandler(
+   }
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
+-  EnsureConstructor(this);
++  EnsureConstructor(isolate, this);
+   i::FunctionTemplateInfo* constructor =
+       i::FunctionTemplateInfo::cast(Utils::OpenHandle(this)->constructor());
+   i::Handle<i::FunctionTemplateInfo> cons(constructor);
+@@ -1611,7 +1627,7 @@ void ObjectTemplate::SetCallAsFunctionHandler(InvocationCallback callback,
+   }
+   ENTER_V8(isolate);
+   i::HandleScope scope(isolate);
+-  EnsureConstructor(this);
++  EnsureConstructor(isolate, this);
+   i::FunctionTemplateInfo* constructor =
+       i::FunctionTemplateInfo::cast(Utils::OpenHandle(this)->constructor());
+   i::Handle<i::FunctionTemplateInfo> cons(constructor);
+@@ -1643,7 +1659,7 @@ void ObjectTemplate::SetInternalFieldCount(int value) {
+     // The internal field count is set by the constructor function's
+     // construct code, so we ensure that there is a constructor
+     // function to do the setting.
+-    EnsureConstructor(this);
++    EnsureConstructor(isolate, this);
+   }
+   Utils::OpenHandle(this)->set_internal_field_count(i::Smi::FromInt(value));
+ }
+@@ -3194,12 +3210,12 @@ Local<String> v8::Object::ObjectProtoToString() {
+   //   return "[object " + c + "]";
+ 
+   if (!name->IsString()) {
+-    return v8::String::New("[object ]");
++    return v8::String::New(reinterpret_cast<Isolate*>(isolate), "[object ]");
+ 
+   } else {
+     i::Handle<i::String> class_name = i::Handle<i::String>::cast(name);
+     if (class_name->IsOneByteEqualTo(STATIC_ASCII_VECTOR("Arguments"))) {
+-      return v8::String::New("[object Object]");
++      return v8::String::New(reinterpret_cast<Isolate*>(isolate), "[object Object]");
+ 
+     } else {
+       const char* prefix = "[object ";
+@@ -3226,7 +3242,7 @@ Local<String> v8::Object::ObjectProtoToString() {
+       memcpy(ptr, postfix, postfix_len * v8::internal::kCharSize);
+ 
+       // Copy the buffer into a heap-allocated string and return it.
+-      Local<String> result = v8::String::New(buf.start(), buf_len);
++      Local<String> result = v8::String::New(reinterpret_cast<Isolate*>(isolate), buf.start(), buf_len);
+       return result;
+     }
+   }
+@@ -3923,12 +3939,13 @@ Handle<Value> Function::GetInferredName() const {
+ ScriptOrigin Function::GetScriptOrigin() const {
+   i::Handle<i::JSFunction> func = Utils::OpenHandle(this);
+   if (func->shared()->script()->IsScript()) {
++    Isolate* v8_isolate = reinterpret_cast<Isolate*>(func->GetIsolate());
+     i::Handle<i::Script> script(i::Script::cast(func->shared()->script()));
+     i::Handle<i::Object> scriptName = GetScriptNameOrSourceURL(script);
+     v8::ScriptOrigin origin(
+       Utils::ToLocal(scriptName),
+-      v8::Integer::New(script->line_offset()->value()),
+-      v8::Integer::New(script->column_offset()->value()));
++      v8::Integer::New(v8_isolate, script->line_offset()->value()),
++      v8::Integer::New(v8_isolate, script->column_offset()->value()));
+     return origin;
+   }
+   return v8::ScriptOrigin(Handle<Value>());
+@@ -4850,9 +4867,9 @@ const char* v8::V8::GetVersion() {
+ 
+ 
+ static i::Handle<i::FunctionTemplateInfo>
+-    EnsureConstructor(i::Handle<i::ObjectTemplateInfo> templ) {
++    EnsureConstructor(i::Isolate* isolate, i::Handle<i::ObjectTemplateInfo> templ) {
+   if (templ->constructor()->IsUndefined()) {
+-    Local<FunctionTemplate> constructor = FunctionTemplate::New();
++    Local<FunctionTemplate> constructor = FunctionTemplate::New(reinterpret_cast<Isolate*>(isolate));
+     Utils::OpenHandle(*constructor)->set_instance_template(*templ);
+     templ->set_constructor(*Utils::OpenHandle(*constructor));
+   }
+@@ -4860,13 +4877,22 @@ static i::Handle<i::FunctionTemplateInfo>
+     i::FunctionTemplateInfo::cast(templ->constructor()));
+ }
+ 
+-
+ Persistent<Context> v8::Context::New(
+     v8::ExtensionConfiguration* extensions,
+     v8::Handle<ObjectTemplate> global_template,
+     v8::Handle<Value> global_object) {
+   i::Isolate::EnsureDefaultIsolate();
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), extensions, global_template, global_object);
++}
++
++Persistent<Context> v8::Context::New(
++    Isolate* _isolate,
++    v8::ExtensionConfiguration* extensions,
++    v8::Handle<ObjectTemplate> global_template,
++    v8::Handle<Value> global_object) {
++  i::Isolate::EnsureDefaultIsolate();
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::Context::New()");
+   LOG_API(isolate, "Context::New");
+   ON_BAILOUT(isolate, "v8::Context::New()", return Persistent<Context>());
+@@ -4882,12 +4908,12 @@ Persistent<Context> v8::Context::New(
+     if (!global_template.IsEmpty()) {
+       // Make sure that the global_template has a constructor.
+       global_constructor =
+-          EnsureConstructor(Utils::OpenHandle(*global_template));
++          EnsureConstructor(isolate, Utils::OpenHandle(*global_template));
+ 
+       // Create a fresh template for the global proxy object.
+-      proxy_template = ObjectTemplate::New();
++      proxy_template = ObjectTemplate::New(reinterpret_cast<Isolate*>(isolate));
+       proxy_constructor =
+-          EnsureConstructor(Utils::OpenHandle(*proxy_template));
++          EnsureConstructor(isolate, Utils::OpenHandle(*proxy_template));
+ 
+       // Set the global template to be the prototype template of
+       // global proxy template.
+@@ -5143,10 +5169,14 @@ bool FunctionTemplate::HasInstance(v8::Handle<v8::Value> value) {
+   return obj->IsInstanceOf(*Utils::OpenHandle(this));
+ }
+ 
+-
+ Local<External> v8::External::New(void* value) {
+-  STATIC_ASSERT(sizeof(value) == sizeof(i::Address));
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), value);
++}
++
++Local<External> v8::External::New(Isolate* _isolate, void* value) {
++  STATIC_ASSERT(sizeof(value) == sizeof(i::Address));
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::External::New()");
+   LOG_API(isolate, "External::New");
+   ENTER_V8(isolate);
+@@ -5170,9 +5200,13 @@ Local<String> v8::String::Empty() {
+   return Utils::ToLocal(isolate->factory()->empty_string());
+ }
+ 
+-
+ Local<String> v8::String::New(const char* data, int length) {
+-  i::Isolate* isolate = i::Isolate::Current();
++  i::Isolate *isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), data, length);
++}
++
++Local<String> v8::String::New(Isolate* _isolate, const char* data, int length) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::String::New()");
+   LOG_API(isolate, "String::New(char)");
+   if (length == 0) return Empty();
+@@ -5197,9 +5231,13 @@ Local<String> v8::String::Concat(Handle<String> left, Handle<String> right) {
+   return Utils::ToLocal(result);
+ }
+ 
+-
+ Local<String> v8::String::NewUndetectable(const char* data, int length) {
+-  i::Isolate* isolate = i::Isolate::Current();
++  i::Isolate *isolate = i::Isolate::Current();
++  return NewUndetectable(reinterpret_cast<Isolate*>(isolate), data, length);
++}
++
++Local<String> v8::String::NewUndetectable(Isolate* _isolate, const char* data, int length) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::String::NewUndetectable()");
+   LOG_API(isolate, "String::NewUndetectable(char)");
+   ENTER_V8(isolate);
+@@ -5218,9 +5256,13 @@ static int TwoByteStringLength(const uint16_t* data) {
+   return length;
+ }
+ 
+-
+ Local<String> v8::String::New(const uint16_t* data, int length) {
+-  i::Isolate* isolate = i::Isolate::Current();
++  i::Isolate *isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), data, length);
++}
++
++Local<String> v8::String::New(Isolate* _isolate, const uint16_t* data, int length) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::String::New()");
+   LOG_API(isolate, "String::New(uint16_)");
+   if (length == 0) return Empty();
+@@ -5232,9 +5274,13 @@ Local<String> v8::String::New(const uint16_t* data, int length) {
+   return Utils::ToLocal(result);
+ }
+ 
+-
+ Local<String> v8::String::NewUndetectable(const uint16_t* data, int length) {
+-  i::Isolate* isolate = i::Isolate::Current();
++  i::Isolate *isolate = i::Isolate::Current();
++  return NewUndetectable(reinterpret_cast<Isolate*>(isolate), data, length);
++}
++
++Local<String> v8::String::NewUndetectable(Isolate* _isolate, const uint16_t* data, int length) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::String::NewUndetectable()");
+   LOG_API(isolate, "String::NewUndetectable(uint16_)");
+   ENTER_V8(isolate);
+@@ -5262,10 +5308,15 @@ i::Handle<i::String> NewExternalAsciiStringHandle(i::Isolate* isolate,
+   return result;
+ }
+ 
++Local<String> v8::String::NewExternal(v8::String::ExternalStringResource* resource) {
++  i::Isolate *isolate = i::Isolate::Current();
++  return NewExternal(reinterpret_cast<Isolate*>(isolate), resource);
++}
+ 
+ Local<String> v8::String::NewExternal(
++      Isolate* _isolate,
+       v8::String::ExternalStringResource* resource) {
+-  i::Isolate* isolate = i::Isolate::Current();
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::String::NewExternal()");
+   LOG_API(isolate, "String::NewExternal");
+   ENTER_V8(isolate);
+@@ -5298,10 +5349,15 @@ bool v8::String::MakeExternal(v8::String::ExternalStringResource* resource) {
+   return result;
+ }
+ 
++Local<String> v8::String::NewExternal(v8::String::ExternalAsciiStringResource* resource) {
++  i::Isolate *isolate = i::Isolate::Current();
++  return NewExternal(reinterpret_cast<Isolate*>(isolate), resource);
++}
+ 
+ Local<String> v8::String::NewExternal(
++      Isolate* _isolate,
+       v8::String::ExternalAsciiStringResource* resource) {
+-  i::Isolate* isolate = i::Isolate::Current();
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::String::NewExternal()");
+   LOG_API(isolate, "String::NewExternal");
+   ENTER_V8(isolate);
+@@ -5348,9 +5404,13 @@ bool v8::String::CanMakeExternal() {
+   return !shape.IsExternal();
+ }
+ 
+-
+ Local<v8::Object> v8::Object::New() {
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate));
++}
++
++Local<v8::Object> v8::Object::New(Isolate* _isolate) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::Object::New()");
+   LOG_API(isolate, "Object::New");
+   ENTER_V8(isolate);
+@@ -5359,9 +5419,13 @@ Local<v8::Object> v8::Object::New() {
+   return Utils::ToLocal(obj);
+ }
+ 
+-
+ Local<v8::Value> v8::NumberObject::New(double value) {
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), value);
++}
++
++Local<v8::Value> v8::NumberObject::New(Isolate* _isolate, double value) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::NumberObject::New()");
+   LOG_API(isolate, "NumberObject::New");
+   ENTER_V8(isolate);
+@@ -5428,9 +5492,13 @@ Local<v8::String> v8::StringObject::StringValue() const {
+       i::Handle<i::String>(i::String::cast(jsvalue->value())));
+ }
+ 
+-
+ Local<v8::Value> v8::Date::New(double time) {
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), time);
++}
++
++Local<v8::Value> v8::Date::New(Isolate* _isolate, double time) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::Date::New()");
+   LOG_API(isolate, "Date::New");
+   if (isnan(time)) {
+@@ -5548,9 +5616,13 @@ v8::RegExp::Flags v8::RegExp::GetFlags() const {
+   return static_cast<RegExp::Flags>(obj->GetFlags().value());
+ }
+ 
+-
+ Local<v8::Array> v8::Array::New(int length) {
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), length);
++}
++
++Local<v8::Array> v8::Array::New(Isolate* _isolate, int length) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::Array::New()");
+   LOG_API(isolate, "Array::New");
+   ENTER_V8(isolate);
+@@ -5597,9 +5669,13 @@ Local<Object> Array::CloneElementAt(uint32_t index) {
+   return Utils::ToLocal(result);
+ }
+ 
+-
+ Local<String> v8::String::NewSymbol(const char* data, int length) {
+   i::Isolate* isolate = i::Isolate::Current();
++  return NewSymbol(reinterpret_cast<Isolate*>(isolate), data, length);
++}
++
++Local<String> v8::String::NewSymbol(Isolate* _isolate, const char* data, int length) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::String::NewSymbol()");
+   LOG_API(isolate, "String::NewSymbol(char)");
+   ENTER_V8(isolate);
+@@ -5609,9 +5685,13 @@ Local<String> v8::String::NewSymbol(const char* data, int length) {
+   return Utils::ToLocal(result);
+ }
+ 
+-
+ Local<Number> v8::Number::New(double value) {
+   i::Isolate* isolate = i::Isolate::Current();
++  return New(reinterpret_cast<Isolate*>(isolate), value);
++}
++
++Local<Number> v8::Number::New(Isolate* _isolate, double value) {
++  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(_isolate);
+   EnsureInitializedForIsolate(isolate, "v8::Number::New()");
+   if (isnan(value)) {
+     // Introduce only canonical NaN value into the VM, to avoid signaling NaNs.
+@@ -5622,22 +5702,12 @@ Local<Number> v8::Number::New(double value) {
+   return Utils::NumberToLocal(result);
+ }
+ 
+-
+ Local<Integer> v8::Integer::New(int32_t value) {
+-  i::Isolate* isolate = i::Isolate::UncheckedCurrent();
+-  EnsureInitializedForIsolate(isolate, "v8::Integer::New()");
+-  return v8::Integer::New(value, reinterpret_cast<Isolate*>(isolate));
+-}
+-
+-
+-Local<Integer> Integer::NewFromUnsigned(uint32_t value) {
+   i::Isolate* isolate = i::Isolate::Current();
+-  EnsureInitializedForIsolate(isolate, "v8::Integer::NewFromUnsigned()");
+-  return Integer::NewFromUnsigned(value, reinterpret_cast<Isolate*>(isolate));
++  return New(reinterpret_cast<Isolate*>(isolate), value);
+ }
+ 
+-
+-Local<Integer> v8::Integer::New(int32_t value, Isolate* isolate) {
++Local<Integer> v8::Integer::New(Isolate* isolate, int32_t value) {
+   i::Isolate* internal_isolate = reinterpret_cast<i::Isolate*>(isolate);
+   ASSERT(internal_isolate->IsInitialized());
+   if (i::Smi::IsValid(value)) {
+@@ -5649,13 +5719,17 @@ Local<Integer> v8::Integer::New(int32_t value, Isolate* isolate) {
+   return Utils::IntegerToLocal(result);
+ }
+ 
++Local<Integer> v8::Integer::NewFromUnsigned(uint32_t value) {
++  i::Isolate* isolate = i::Isolate::Current();
++  return NewFromUnsigned(reinterpret_cast<Isolate*>(isolate), value);
++}
+ 
+-Local<Integer> v8::Integer::NewFromUnsigned(uint32_t value, Isolate* isolate) {
++Local<Integer> v8::Integer::NewFromUnsigned(Isolate* isolate, uint32_t value) {
+   i::Isolate* internal_isolate = reinterpret_cast<i::Isolate*>(isolate);
+   ASSERT(internal_isolate->IsInitialized());
+   bool fits_into_int32_t = (value & (1 << 31)) == 0;
+   if (fits_into_int32_t) {
+-    return Integer::New(static_cast<int32_t>(value), isolate);
++    return Integer::New(isolate, static_cast<int32_t>(value));
+   }
+   ENTER_V8(internal_isolate);
+   i::Handle<i::Object> result = internal_isolate->factory()->NewNumber(value);
+diff --git a/test/cctest/test-decls.cc b/test/cctest/test-decls.cc
+index ae2ec71..bdb420c 100644
+--- a/test/cctest/test-decls.cc
++++ b/test/cctest/test-decls.cc
+@@ -695,7 +695,7 @@ TEST(ExistsInHiddenPrototype) {
+ class SimpleContext {
+  public:
+   SimpleContext() {
+-    context_ = Context::New(0);
++    context_ = Context::New(v8::Isolate::GetCurrent(), 0);
+     context_->Enter();
+   }
+ 

--- a/recipes-www/v8/v8_3.17.16.bb
+++ b/recipes-www/v8/v8_3.17.16.bb
@@ -1,8 +1,10 @@
 include v8.inc
-SRC_URI = "svn://v8.googlecode.com/svn;protocol=https;module=tags/3.17.16.2;rev=25343;path_spec=${BPN}-${PV} \
-    svn://gyp.googlecode.com/svn;module=trunk;protocol=https;rev=1501;path_spec=${BPN}-${PV}/build/gyp \
+SRC_URI = "\
+    git://git@bitbucket.org/rdm-dev/v8-armv5-serguei.git;protocol=ssh;branch=trunk;tag=${PV};destsuffix=${BPN}-${PV} \
+    git://chromium.googlesource.com/external/gyp;protocol=https;rev=f7bc250ccc4d619a1cf238db87e5979f89ff36d7;destsuffix=${BPN}-${PV}/build/gyp \
     file://v8-bignum-strict-overflow.patch;striplevel=0 \
     file://v8-sane-arm5e-handling.patch;striplevel=0 \
+    file://v8_3.17.16-weird-dirty-serguei.patch \
 "
 
 do_patch_ancient_v8 () {

--- a/recipes-www/v8/v8_3.24.37.bb
+++ b/recipes-www/v8/v8_3.24.37.bb
@@ -1,8 +1,9 @@
 include v8.inc
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}-${PV}:"
-SRC_URI = "svn://v8.googlecode.com/svn;protocol=https;module=tags/3.24.37;rev=23139;path_spec=${BPN}-${PV} \
-    svn://gyp.googlecode.com/svn;module=trunk;protocol=https;rev=1831;path_spec=${BPN}-${PV}/build/gyp \
-    svn://src.chromium.org/chrome/trunk;module=deps/third_party/icu46;protocol=https;rev=239289;path_spec=${BPN}-${PV}/third_party/icu \
+SRC_URI = "\
+    git://chromium.googlesource.com/v8/v8.git;protocol=https;branch=candidates;tag=${PV};destsuffix=${BPN}-${PV} \
+    git://chromium.googlesource.com/external/gyp;protocol=https;rev=a3e2a5caf24a1e0a45401e09ad131210bf16b852;destsuffix=${BPN}-${PV}/build/gyp \
+    git://chromium.googlesource.com/chromium/deps/icu46;protocol=https;rev=83ca4e6be97c8117f2ec163a96d0bbab5ffd0069;destsuffix=${BPN}-${PV}/third_party/icu \
     file://v8-3.22-RPi.patch;striplevel=0 \
     file://v8-arraybuffer.patch;striplevel=0 \
     file://v8-bignum-strict-overflow.patch;striplevel=0 \

--- a/recipes-www/v8/v8_svn.bb
+++ b/recipes-www/v8/v8_svn.bb
@@ -1,7 +1,0 @@
-include v8.inc
-SRC_URI = "svn://v8.googlecode.com/svn;protocol=https;module=trunk;rev=23139;path_spec=v8 \
-svn://gyp.googlecode.com/svn;module=trunk;protocol=https;rev=1831;path_spec=v8/build/gyp \
-svn://src.chromium.org/chrome/trunk;module=deps/third_party/icu52;protocol=https;rev=277999;path_spec=v8/third_party/icu \
-git://chromium.googlesource.com/chromium/buildtools.git;rev=fb782d4369d5ae04f17a2fceef7de5a63e50f07b;protocol=https \
-svn://googletest.googlecode.com/svn;module=trunk;protocol=http;rev=692;path_spec=v8/testing/gtest \
-svn://googlemock.googlecode.com/svn;module=trunk;protocol=http;rev=485;path_spec=v8/testing/gmock "


### PR DESCRIPTION
Instead of initial requested svn revision, Serguei (Z-Wave.me) nowadays
requires ancient versions via git-commit. The ARM5 version relies on
an apparently unclean fork in the middle of svn2git conversion of v8
bundled with an undocumented backport of depreciated features.

Signed-off-by: Jens Rehsack sno@netbsd.org
