### PR TITLE
deploy-images: fix name extraction pattern

### DIFF
--- a/scripts/deployimgs
+++ b/scripts/deployimgs
@@ -23,6 +23,7 @@ do
     DEPLOY_DIR_IMAGE="${DEPLOY_DIR_IMAGE_BASE}/${MACHINE}"
 
     SYSIMG_VERSION=${SYSIMG_VERSION:-$(. ${DEPLOY_DIR_IMAGE}/.settings; echo ${SYSIMG_VER})}
+    WANTED_ROOT_DEV=$(. ${DEPLOY_DIR_IMAGE}/.settings; echo ${WANTED_ROOT_DEV})
     for IMAGE in ${DEPLOY_DIR_IMAGE}/*-${SYSIMG_VERSION}-complete.cpi
     do
 	SPC=""
@@ -34,7 +35,7 @@ do
 	done
 	HASH="${HASH}${SPC}size=`stat -c %s "${IMAGE}"`"
 	IMAGE=`echo ${IMAGE} | sed -e "s,${DEPLOY_DIR_IMAGE_BASE}/,,"`
-	NAME=`echo ${IMAGE} | sed -e "s,rdm-,," -e "s,-image-${SYSIMG_VERSION}-complete.cpi,," -e 's,-,+,g'`
+	NAME=`echo ${IMAGE} | sed -e "s,rdm-,," -e "s,-image-${WANTED_ROOT_DEV}-${SYSIMG_VERSION}-complete.cpi,," -e 's,-,+,g'`
 	MANI="${MANI}${MANISPC}\"${NAME}\": \"${IMAGE};${HASH}\""
 	MANISPC=",
 	"


### PR DESCRIPTION
With 4.1 images contain the root device in image name to avoid conflicts
between images for internal storage and several external boot devices.
The affected pattern received appropriate upgrade.

Signed-off-by: Jens Rehsack sno@netbsd.org
