### PR TITLE
samba: configure smb.conf to avoid syslog spamming

### DIFF
--- a/recipes-connectivity/samba/samba/smb.conf
+++ b/recipes-connectivity/samba/samba/smb.conf
@@ -2,6 +2,7 @@
 interfaces = eth*, wlan*
 log level = 0
 log file = /var/log/samba.log
+syslog = 0
 max log size = 4096
 enable core files = No
 max protocol = SMB2


### PR DESCRIPTION
- samba: configure smb.conf to avoid syslog spamming
