### PR TITLE
allow wlan to startup at boot

### DIFF
--- a/recipes-core/init-ifupdown/init-ifupdown/activate.pl
+++ b/recipes-core/init-ifupdown/init-ifupdown/activate.pl
@@ -14,7 +14,7 @@ my %mapping = map { chomp; split } (<>);
 my $status;
 
 if ( $devname =~ m/^wlan/
-    and ( read_file("/etc/wpa_supplicant.conf") !~ m/network=\{\s+ssid/ms or read_file("/sys/class/net/eth0/carrier") == 1 ) )
+    and ( read_file("/etc/wpa_supplicant.conf") !~ m/network=\{\s+ssid/ms or eval { read_file("/sys/class/net/eth0/carrier") == 1 } ) )
 {
     $status = "NONET";
 }


### PR DESCRIPTION
added an eval in order to allow wlan start event if eth carrier cannot be read

Signed-off-by: Volker volker.moesker@rademacher.de
