### PR TITLE
nginx cleanup and proxy timeouts

### DIFF
--- a/recipes-httpd/nginx/files/nginx.conf
+++ b/recipes-httpd/nginx/files/nginx.conf
@@ -69,12 +69,12 @@ http {
             proxy_send_timeout 240s;
         }
 
-	location /service/favs {
-	    alias /var/www/localhost/favs;
-	}
+        location /service/favs {
+            alias /var/www/localhost/favs;
+        }
 
         location /zwave {
-            rewrite ^ http://$server_addr:8083/ permanent;
+            return 301 http://$server_addr:8083/;
         }
 
         location /legal {
@@ -87,11 +87,11 @@ http {
         }
 
         location /xbmc {
-            rewrite ^ /system.do?show=update permanent;
+            return 301 /system.do?show=update;
         }
 
         location /mediaplayer {
-            rewrite ^ /system.do?show=update permanent;
+            return 301 /system.do?show=update;
         }
 
         #error_page  404              /404.html;

--- a/recipes-httpd/nginx/files/nginx.conf
+++ b/recipes-httpd/nginx/files/nginx.conf
@@ -53,6 +53,9 @@ http {
             #root   /var/www/localhost/html;
             #index  index.html index.htm;
             proxy_pass http://127.0.0.1:8079;
+            proxy_connect_timeout 240s;
+            proxy_read_timeout 240s;
+            proxy_send_timeout 240s;
         }
 
         location /nginx_status {

--- a/recipes-httpd/nginx/files/nginx.conf
+++ b/recipes-httpd/nginx/files/nginx.conf
@@ -58,12 +58,6 @@ http {
             proxy_send_timeout 240s;
         }
 
-        location /nginx_status {
-            stub_status on;
-            allow 127.0.0.1;
-            deny all;
-        }
-
         location /service/ {
             rewrite ^/service/?(.*) /$1 break;
             proxy_pass http://127.0.0.1:8081;

--- a/recipes-httpd/nginx/nginx_%.bbappend
+++ b/recipes-httpd/nginx/nginx_%.bbappend
@@ -10,10 +10,6 @@ SRCREV_html = "f5cd9dc38fe3b2d58a48242fcf224a738b311610"
 
 PACKAGES_prepend = "${PN}-favs ${PN}-legal ${PN}-manual "
 
-EXTRA_OECONF_append = "\
-    --with-http_stub_status_module \
-"
-
 do_install_append () {
 	install -d ${D}${localstatedir}/lib/nginx/
 	install -d ${D}${sysconfdir}/default/volatiles


### PR DESCRIPTION
- nginx: cleanup nginx configuration
- nginx: configure proxy timeouts for the root location
- nginx: disable http_stub_status_module
