### PR TITLE
linux-bohr: disable mv643xx_eth tso by default

### DIFF
--- a/recipes-kernel/linux/linux-bohr-4.1/net-mv643xx-disable-tso-by-default.patch
+++ b/recipes-kernel/linux/linux-bohr-4.1/net-mv643xx-disable-tso-by-default.patch
@@ -1,0 +1,53 @@
+From patchwork Sat Nov  1 15:30:20 2014
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: [1/1] net: mv643xx_eth: Make TSO disabled by default
+From: Ezequiel Garcia <ezequiel.garcia@free-electrons.com>
+X-Patchwork-Id: 405792
+Message-Id: <1414855820-15094-2-git-send-email-ezequiel.garcia@free-electrons.com>
+To: <netdev@vger.kernel.org>, David Miller <davem@davemloft.net>
+Cc: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>,
+ Gregory Clement <gregory.clement@free-electrons.com>,
+ Tawfik Bayouk <tawfik@marvell.com>, Lior Amsalem <alior@marvell.com>,
+ Nadav Haklai <nadavh@marvell.com>,
+ Ezequiel Garcia <ezequiel.garcia@free-electrons.com>
+Date: Sat,  1 Nov 2014 12:30:20 -0300
+
+Data corruption has been observed to be produced by TSO. For instance,
+accessing files on a NFS-server with TSO enabled results in different data
+transferred each time.
+
+This has been observed only on Kirkwood platforms, i.e. with the mv643xx_eth
+driver. Same tests on platforms using the mvneta ethernet driver have
+passed without errors.
+
+Make TSO disabled by default for now, until we can found a proper fix
+for the regression.
+
+Fixes: 3ae8f4e0b98 ('net: mv643xx_eth: Implement software TSO')
+Reported-by: Slawomir Gajzner <slawomir.gajzner@gmail.com>
+Reported-by: Julien D'Ascenzio <jdascenzio@yahoo.fr>
+Signed-off-by: Ezequiel Garcia <ezequiel.garcia@free-electrons.com>
+---
+ drivers/net/ethernet/marvell/mv643xx_eth.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/marvell/mv643xx_eth.c b/drivers/net/ethernet/marvell/mv643xx_eth.c
+index b151a94..8b72780 100644
+--- a/drivers/net/ethernet/marvell/mv643xx_eth.c
++++ b/drivers/net/ethernet/marvell/mv643xx_eth.c
+@@ -3110,11 +3110,11 @@ static int mv643xx_eth_probe(struct platform_device *pdev)
+ 	dev->watchdog_timeo = 2 * HZ;
+ 	dev->base_addr = 0;
+ 
+-	dev->features = NETIF_F_SG | NETIF_F_IP_CSUM | NETIF_F_TSO;
++	dev->features = NETIF_F_SG | NETIF_F_IP_CSUM;
+ 	dev->vlan_features = dev->features;
+ 
+ 	dev->features |= NETIF_F_RXCSUM;
+-	dev->hw_features = dev->features;
++	dev->hw_features = dev->features  | NETIF_F_TSO;
+ 
+ 	dev->priv_flags |= IFF_UNICAST_FLT;
+ 	dev->gso_max_segs = MV643XX_MAX_TSO_SEGS;

--- a/recipes-kernel/linux/linux-bohr_4.1.bb
+++ b/recipes-kernel/linux/linux-bohr_4.1.bb
@@ -20,6 +20,7 @@ SRCBRANCH = "bohr_4.1.18"
 SRC_URI = "git://github.com/${SRCREPO}/linux-curie.git;branch=${SRCBRANCH};rev=${REV} \
 	   file://defconfig \
 	   file://omit-to-optimize-some-printf.patch \
+	   file://net-mv643xx-disable-tso-by-default.patch \
           "
 
 # patches for hp


### PR DESCRIPTION
- linux-bohr: disable mv643xx_eth tso by default
