### PR TITLE
changed update manifest to manifest-4.4.json

### DIFF
--- a/recipes-rdm/system-image/files/sysimg_update.json
+++ b/recipes-rdm/system-image/files/sysimg_update.json
@@ -7,7 +7,7 @@
             [ "Screen", "min_level", "debug", "newline", 1, "stderr", 1 ]
         ]
     ],
-    "update_manifest_basename" : "manifest-4.1.json",
+    "update_manifest_basename" : "manifest-4.4.json",
     "download_file_prefix": "@MACHINE@/",
     "restrict_record_installed": [ "system-image" ],
     "record_installed_aliases": {


### PR DESCRIPTION
according to ticket HPBLOB-1563
Note: requires also PR in HP2SM: 
https://bitbucket.org/rdm-dev/hp2sm/pull-requests/42/changed-update-manifest-to-manifest-44json/diff

Signed-off-by: Volker volker.moesker@rademacher.de
