### PR TITLE
udev trigger instead of restart

### DIFF
--- a/recipes-core/udev/udev/restart-udev.sh
+++ b/recipes-core/udev/udev/restart-udev.sh
@@ -5,8 +5,8 @@
 # Required-Stop: 
 # Default-Start:     3 5
 # Default-Stop:
-# Short-Description: restart udev to catch missing signals
+# Short-Description: re-trigger udev add to catch missing signals
 # Description:
 ### END INIT INFO
 
-/etc/init.d/udev restart
+/usr/bin/udevadm trigger -c add


### PR DESCRIPTION
fix z-wave stick detection lock by doing trigger instead of reload
see ticket HPBLOB-1998

Signed-off-by: Volker volker.moesker@rademacher.de
